### PR TITLE
Fixes CHEF-2191

### DIFF
--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -226,7 +226,7 @@ class Chef
         puts("\n")
 
         puts "#{ui.color("Public DNS Name", :cyan)}: #{server.dns_name}"
-        puts "#{ui.color("Public IP Address", :cyan)}: #{server.ip_address}"
+        puts "#{ui.color("Public IP Address", :cyan)}: #{server.public_ip_address}"
         puts "#{ui.color("Private DNS Name", :cyan)}: #{server.private_dns_name}"
         puts "#{ui.color("Private IP Address", :cyan)}: #{server.private_ip_address}"
 
@@ -246,7 +246,7 @@ class Chef
         puts "#{ui.color("Availability Zone", :cyan)}: #{server.availability_zone}"
         puts "#{ui.color("Security Groups", :cyan)}: #{server.groups.join(", ")}"
         puts "#{ui.color("Public DNS Name", :cyan)}: #{server.dns_name}"
-        puts "#{ui.color("Public IP Address", :cyan)}: #{server.ip_address}"
+        puts "#{ui.color("Public IP Address", :cyan)}: #{server.public_ip_address}"
         puts "#{ui.color("Private DNS Name", :cyan)}: #{server.private_dns_name}"
         puts "#{ui.color("SSH Key", :cyan)}: #{server.key_name}"
         puts "#{ui.color("Private IP Address", :cyan)}: #{server.private_ip_address}"

--- a/lib/chef/knife/openstack_server_delete.rb
+++ b/lib/chef/knife/openstack_server_delete.rb
@@ -72,7 +72,7 @@ class Chef
           msg("Security Groups", server.groups.join(", "))
           msg("SSH Key", server.key_name)
           msg("Public DNS Name", server.dns_name)
-          msg("Public IP Address", server.ip_address)
+          msg("Public IP Address", server.public_ip_address)
           msg("Private DNS Name", server.private_dns_name)
           msg("Private IP Address", server.private_ip_address)
 

--- a/lib/chef/knife/openstack_server_list.rb
+++ b/lib/chef/knife/openstack_server_list.rb
@@ -76,7 +76,8 @@ class Chef
         ]
         connection.servers.all.each do |server|
           server_list << server.id.to_s
-          server_list << (server.ip_address == nil ? "" : server.public_ip_address)
+          # HACK these should all be server.blah.to_s as nil.to_s == ''
+          server_list << (server.public_ip_address == nil ? "" : server.public_ip_address)
           server_list << (server.private_ip_address == nil ? "" : server.private_ip_address)
           server_list << (server.flavor_id == nil ? "" : server.flavor_id)
           server_list << (server.image_id == nil ? "" : server.image_id)


### PR DESCRIPTION
knife-openstack uses #ip_address which is deprecated.  This pull request uses public_ip_address
