### PR TITLE
Catch Net Unreachable error

### DIFF
--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -140,7 +140,7 @@ class Chef
       rescue Errno::ECONNREFUSED
         sleep 2
         false
-      rescue Errno::EHOSTUNREACH
+      rescue Errno::EHOSTUNREACH, Errno::ENETUNREACH
         sleep 2
         false
       ensure


### PR DESCRIPTION
If you're routing through the host machine to the private network OpenStack maintains for instances, you will get a Network Unreachable exception until OpenStack sets up the proper route which happens once the machine boots.

This will catch that error and allow the script to wait until the machine and the network is ready.
