### PR TITLE
Pass ssh_password to bootstrap

### DIFF
--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -268,6 +268,7 @@ class Chef
       bootstrap.name_args = [bootstrap_ip_address]
       bootstrap.config[:run_list] = config[:run_list]
       bootstrap.config[:ssh_user] = config[:ssh_user]
+      bootstrap.config[:ssh_password] = config[:ssh_password]
       bootstrap.config[:identity_file] = config[:identity_file]
       bootstrap.config[:host_key_verify] = config[:host_key_verify]
       bootstrap.config[:chef_node_name] = server.name


### PR DESCRIPTION
The bootstrap supports supplying the ssh password if key auth doesnt work. This fix will pass along the ssh_password to bootstrap so it can be used, without it the bootstrap process hangs waiting for user input
