### PR TITLE
Guard against NoMethodError for image.name in image list

### DIFF
--- a/lib/chef/knife/openstack_image_list.rb
+++ b/lib/chef/knife/openstack_image_list.rb
@@ -41,7 +41,7 @@ class Chef
         ]
 
         connection.images.sort_by do |image|
-          [image.name.downcase, image.id].compact
+          [image.name.to_s.downcase, image.id].compact
         end.each do |image|
           image_list << image.id
           image_list << image.name


### PR DESCRIPTION
Image lists containing images with empty names cause knife to fail.

<pre><code>$ knife openstack image list 
Exception: NoMethodError: undefined method `downcase' for nil:NilClass</code></pre>


Fixed by including to_s method prior to the downcase method on image.name.
