### PR TITLE
Fix nil exception during configuring floating ip on some openstack installations

### DIFF
--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -215,6 +215,7 @@ class Chef
           if address.instance_id.nil?
             server.associate_address(address.ip)
             #a bit of a hack, but server.reload takes a long time
+            server.addresses['public'] = [] if server.addresses['public'].nil?
             server.addresses['public'].push({"version"=>4,"addr"=>address.ip})
             associated = true
             msg_pair("Floating IP Address", address.ip)


### PR DESCRIPTION
Fix nil exception during configuring floating ip on some openstack installations.

Some openstack installations REST JSON response does not contain array
public with list of public IP. Due to this, Ruby object representation
does not contain addresses['public'] and
push({"version"=>4,"addr"=>address.ip}) causes nil exception.

Fix creates empty array addresses['public'] when nil.
