### PR TITLE
Check for server.addresses['public'] before pushing new value into it.

### DIFF
--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -215,6 +215,11 @@ class Chef
           if address.instance_id.nil?
             server.associate_address(address.ip)
             #a bit of a hack, but server.reload takes a long time
+
+            unless server.addresses.has_key?('public')
+              server.addresses['public'] = []
+            end
+
             server.addresses['public'].push({"version"=>4,"addr"=>address.ip})
             associated = true
             msg_pair("Floating IP Address", address.ip)


### PR DESCRIPTION
When running knife-openstack against a private
install of openstack folsom, instances do not
populate server.addresses['public'].

The result was an undefined method exception
being raised when trying to push the floating ip
address to server.addresses['public'].

This fix checks for the existence of the 'public' key
first, creates it if it does not exist, then
pushes the floating IP into the array.
