### PR TITLE
[KNIFE-231] and [KNIFE-277] workaround

### DIFF
--- a/lib/chef/knife/openstack_base.rb
+++ b/lib/chef/knife/openstack_base.rb
@@ -124,6 +124,8 @@ class Chef
       def primary_private_ip_address(addresses)
         if addresses['private']
           return addresses['private'].last['addr']
+        else
+	        return any_address(addresses)
         end
       end
 
@@ -131,8 +133,23 @@ class Chef
       def primary_public_ip_address(addresses)
         if addresses['public']
           return addresses['public'].last['addr']
+        else
+	        return any_address(addresses)
         end
       end
+
+      # Grab the first address
+      def any_address(addresses)
+	      # Check if any addesses are available.
+	      if addresses.empty?
+		      Chef::Log.warn("No IPs available")
+		      return nil
+	      else
+		      # Grab first available address
+		      addresses[addresses.keys[0]].last['addr']
+	      end
+      end
+
 
     end
   end


### PR DESCRIPTION
Changed address fetching code to fall back to grabbing the first available address if an interface with the specified name is not found. This prevents knife from throwing an exception if none of the networks are called either "private" or "public".

I'm in the situation where are multiple Openstack cells, the network in each is named differently and I can't control which cell my VM is started in so being able to specify the network name doesn't help.
