### PR TITLE
OC-10521 knife-cloud: knife openstack should support summary display during create and new command 

### DIFF
--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -50,7 +50,23 @@ class Chef
               :server_create_timeout => locate_config_value(:server_create_timeout)
             }
             Chef::Log.debug("Create server params - server_def = #{@create_options[:server_def]}")
+
+            #set columns_with_info map
+            @columns_with_info = [
+            {:label => 'Instance ID', :key => 'id'},
+            {:label => 'Name', :key => 'name'},
+            {:label => 'Public IP', :key => 'addresses', :value_callback => method(:primary_public_ip_address)},
+            {:label => 'Private IP', :key => 'addresses', :value_callback => method(:primary_private_ip_address)},
+            {:label => 'Flavor', :key => 'flavor', :value_callback => method(:get_id)},
+            {:label => 'Image', :key => 'image', :value_callback => method(:get_id)},
+            {:label => 'Keypair', :key => 'key_name'},
+            {:label => 'State', :key => 'state'}
+            ]
             super
+        end
+
+        def get_id(value)
+          value['id']
         end
 
         # Setup the floating ip after server creation.

--- a/spec/functional/server_create_func_spec.rb
+++ b/spec/functional/server_create_func_spec.rb
@@ -77,6 +77,7 @@ describe Chef::Knife::Cloud::OpenstackServerCreate do
         @bootstrapper.stub(:bootstrap).and_call_original
         @bootstrapper.should_receive(:create_bootstrap_protocol).and_return(@ssh_bootstrap_protocol)
         @bootstrapper.should_receive(:create_bootstrap_distribution).and_return(@unix_distribution)
+        @openstack_service.should_receive(:server_summary).exactly(2).times
         @knife_openstack_create.run
       end
     end
@@ -97,6 +98,7 @@ describe Chef::Knife::Cloud::OpenstackServerCreate do
         @bootstrapper.should_receive(:create_bootstrap_protocol).and_return(@winrm_bootstrap_protocol)
         @bootstrapper.should_receive(:create_bootstrap_distribution).and_return(@windows_distribution)
         @winrm_bootstrap_protocol.stub(:send_bootstrap_command)
+        @openstack_service.should_receive(:server_summary).exactly(2).times
         @knife_openstack_create.run
       end
     end


### PR DESCRIPTION
Added changes to display server summary during server create.
Fixed functional tests.
Integration tests are pending...
It depends on https://github.com/ClogenyTechnologies/knife-cloud/pull/6 for knife-cloud changes.
PBI ref: https://tickets.corp.opscode.com/browse/OC-10521

^adamedx 
