### PR TITLE
Update openstack_server_create.rb

### DIFF
--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -381,7 +381,7 @@ class Chef
           Chef::Log.debug("Waiting for sshd on IP address: #{bootstrap_ip_address} and port: #{locate_config_value(:ssh_port)}")
           print "\n#{ui.color("Waiting for sshd", :magenta)}"
           print(".") until tcp_test_ssh(bootstrap_ip_address, locate_config_value(:ssh_port)) {
-            sleep @initial_sleep_delay ||= 10
+            sleep @initial_sleep_delay ||= 60
             puts("done")
           }
           bootstrap_for_node(server, bootstrap_ip_address).run


### PR DESCRIPTION
When running 'knife openstack server create ....blah blah blah' you may see an error:
Waiting for sshd.....done
Connecting to 74.118.85.161
ERROR: Network Error: Connection refused - connect(2) for "74.118.85.161" port 22
 
This means that the node is trying to be bootstrapped but nothing can connect to it because SSHD is not ready.
The solution is to give it more time.
Find the openstack_server_create.rb on your system. Typically here:
/home/cloud-user/.rvm/gems/ruby-2.1.0/gems/knife-openstack-0.9.1/lib/chef/knife/openstack_server_create.rb
Edit the line:
sleep @initial_sleep_delay ||= 10
To:
sleep @initial_sleep_delay ||= 60
If 60 doesn't work then increase the time