### PR TITLE
KNIFE-474 knife openstack group list throws a fog deprecation warning

### DIFF
--- a/lib/chef/knife/openstack_group_list.rb
+++ b/lib/chef/knife/openstack_group_list.rb
@@ -31,13 +31,13 @@ class Chef
             ui.color('Description', :bold),
           ]
           security_groups.sort_by(&:name).each do |group|
-            group.rules.each do |rule|
-              unless rule['ip_protocol'].nil?
+            group.security_group_rules.each do |rule|
+              unless rule.ip_protocol.nil?
                 group_list << group.name
-                group_list << rule['ip_protocol']
-                group_list << rule['from_port'].to_s
-                group_list << rule['to_port'].to_s
-                group_list << rule['ip_range']['cidr']
+                group_list << rule.ip_protocol
+                group_list << rule.from_port.to_s
+                group_list << rule.to_port.to_s
+                group_list << rule.ip_range['cidr']
                 group_list << group.description
               end
             end

--- a/spec/unit/openstack_group_list_spec.rb
+++ b/spec/unit/openstack_group_list_spec.rb
@@ -39,5 +39,14 @@ describe Chef::Knife::Cloud::OpenstackGroupList do
     end
   end
 
+  context "#list" do
+    before(:each) do
+      @security_groups = [TestResource.new({ "name" => "Unrestricted","description" => "testdescription", "security_group_rules" => [TestResource.new({"from_port"=>636, "group"=>{}, "ip_protocol"=>"tcp", "to_port"=>636, "parent_group_id"=>14, "ip_range"=>{"cidr"=>"0.0.0.0/0"}, "id"=>183})]})]
+    end
 
+    it "returns group list" do
+      instance.ui.should_receive(:list).with(["Name", "Protocol", "From", "To", "CIDR", "Description", "Unrestricted", "tcp", "636", "636", "0.0.0.0/0", "testdescription"],:uneven_columns_across, 6)
+      instance.list(@security_groups)
+    end
+  end
 end


### PR DESCRIPTION
Changes to update new security_group_rules method from deprecated rules.
^@muktaa 
