### PR TITLE
KNIFE-494 add options for secret and secret_file to support encrypted data bags

### DIFF
--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -533,7 +533,7 @@ class Chef
           ui.warn(<<-WARNING)
 Specifying the encrypted data bag secret key using an 'encrypted_data_bag_secret'
 entry in 'knife.rb' is deprecated. Please see CHEF-4011 for more details. You
-can supress this warning and still distribute the secret key to all bootstrapped
+can suppress this warning and still distribute the secret key to all bootstrapped
 machines by adding the following to your 'knife.rb' file:
 
   knife[:secret_file] = "/path/to/your/secret"


### PR DESCRIPTION
When using encrypted data bags, the current plugin uses the soon to be deprecated encrypted_data_bag_secret and encrypted_data_bag_secret_file options. This patch updates knife openstack server create to use the same functionality as knife bootstrap. Also it allows for command line switches to use this functionality instead of having to embed it in the knife.rb file.

The warning included was copied directly out of knife bootstrap.
