### PR TITLE
Allow specifying fixed IPs for new instances

### DIFF
--- a/spec/unit/openstack_server_create_spec.rb
+++ b/spec/unit/openstack_server_create_spec.rb
@@ -90,6 +90,14 @@ describe Chef::Knife::OpenstackServerCreate do
     it "user_data should be empty" do
         Chef::Config[:knife][:user_data].should == nil
     end
+
+    it "doesn't set any network IDs" do
+        Chef::Config[:knife][:network_ids].should == nil
+    end
+
+    it "doesn't set any fixed IP pairs" do
+        Chef::Config[:knife][:fixed_ips].should == nil
+    end
   end
 
   describe "run" do


### PR DESCRIPTION
It is possible to specify a VMs network interfaces using port IDs.  This
allows for predetermining the IP address a VM will use in a subnet.

  --fixed-ips 0fba3583-7f74-49f8-aa1d-8746fee7479f=10.0.0.54

The code takes care of the situation where an unused port with that IP address in that subnet already exists and takes that one.