### PR TITLE
fix ipaddress display

### DIFF
--- a/lib/chef/knife/openstack_base.rb
+++ b/lib/chef/knife/openstack_base.rb
@@ -163,7 +163,16 @@ class Chef
       end
 
       def primary_private_ip_address(addresses)
-        primary_network_ip_address(addresses, 'private')
+        if primary_network_ip_address(addresses, 'private').nil?
+          addr = addresses.map { |k,v|  v.map {|a| a['addr']}}.flatten
+          if addr.length == 1
+            addr[0]
+          else
+            addr.to_s.gsub(/"/,'')
+          end
+        else
+          primary_network_ip_address(addresses, 'private')
+        end
       end
 
       #we use last since the floating IP goes there


### PR DESCRIPTION
In some openstack installations (like ours) that are not using private/public network architecture `knife openstack server list` command don't display any ip address on either public or private fields. 
This patch solve this by displaying all the ip addresses associated with an instance when the instance don't have a private network.