### PR TITLE
better information display on `knife openstack server list`

### DIFF
--- a/lib/chef/knife/openstack_base.rb
+++ b/lib/chef/knife/openstack_base.rb
@@ -203,7 +203,7 @@ class Chef
       end
 
       def get_image_by_id(image_id)
-        @images_list = connection.images
+        @images_list ||= connection.images
         @images_list.find { |i| i.id == image_id }.name
       end
 

--- a/lib/chef/knife/openstack_base.rb
+++ b/lib/chef/knife/openstack_base.rb
@@ -177,6 +177,36 @@ class Chef
         end
       end
 
+      # method copyed from knife-ec2
+      def fcolor(flavor)
+        case flavor
+        when "t1.micro"
+          fcolor = :blue
+        when "m1.small"
+          fcolor = :magenta
+        when "m1.medium"
+          fcolor = :cyan
+        when "m1.large"
+          fcolor = :green
+        when "m1.xlarge"
+          fcolor = :red
+        end
+      end
+
+      def get_flavor_display(id)
+        ui.color(get_flavor_by_id(id), fcolor(get_flavor_by_id(id)))
+      end
+
+      def get_flavor_by_id(flavor_id)
+        @flavor_list ||= connection.flavors
+        @flavor_list.find { |f| f.id == flavor_id }.name
+      end
+
+      def get_image_by_id(image_id)
+        @images_list = connection.images
+        @images_list.find { |i| i.id == image_id }.name
+      end
+
     end
   end
 end

--- a/lib/chef/knife/openstack_server_list.rb
+++ b/lib/chef/knife/openstack_server_list.rb
@@ -59,9 +59,9 @@ class Chef
             else
               server_list << ''
             end
-            server_list << server.flavor['id'].to_s
+            server_list << get_flavor_display(server.flavor['id'])
             if server.image
-              server_list << server.image['id']
+              server_list << get_image_by_id(server.image['id'])
             else
               server_list << ""
             end


### PR DESCRIPTION
Better display information on `knife openstack server list` showing flavor name and image name instead of their id.  Also I added flavor coloring scheme from knife-ec2 for those who use the same flavor names as AWS. 