### PR TITLE
added volume list command

### DIFF
--- a/lib/chef/knife/openstack_base.rb
+++ b/lib/chef/knife/openstack_base.rb
@@ -79,6 +79,41 @@ class Chef
         end
       end
 
+      def storage(type = 'Nova')
+        Chef::Log.debug("openstack_username #{Chef::Config[:knife][:openstack_username]}")
+        Chef::Log.debug("openstack_auth_url #{Chef::Config[:knife][:openstack_auth_url]}")
+        Chef::Log.debug("openstack_endpoint_type #{Chef::Config[:knife][:openstack_endpoint_type] || 'publicURL' }")
+        Chef::Log.debug("openstack_tenant #{Chef::Config[:knife][:openstack_tenant]}")
+        Chef::Log.debug("openstack_insecure #{Chef::Config[:knife][:openstack_insecure].to_s}")
+
+        @storage||= begin
+          connection_params = {
+            :provider => 'OpenStack',
+            :openstack_username => Chef::Config[:knife][:openstack_username],
+            :openstack_api_key => Chef::Config[:knife][:openstack_password],
+            :openstack_auth_url => Chef::Config[:knife][:openstack_auth_url],
+            :openstack_endpoint_type => Chef::Config[:knife][:openstack_endpoint_type],
+            :openstack_tenant => Chef::Config[:knife][:openstack_tenant],
+            :connection_options => {
+              :ssl_verify_peer => !Chef::Config[:knife][:openstack_insecure]
+            }
+          }
+          if type == 'Cinder'
+            storage = Fog::Volume.new(connection_params)
+          else
+            # Nova connection
+            storage = Fog::Compute.new(connection_params)
+          end
+          storage
+          rescue Excon::Errors::Unauthorized => e
+            ui.fatal("Connection failure, please check your OpenStack username and password.")
+            exit 1
+          rescue Excon::Errors::SocketError => e
+            ui.fatal("Connection failure, please check your OpenStack authentication URL.")
+            exit 1
+          end
+      end
+
       def connection
         Chef::Log.debug("openstack_username #{Chef::Config[:knife][:openstack_username]}")
         Chef::Log.debug("openstack_auth_url #{Chef::Config[:knife][:openstack_auth_url]}")
@@ -175,6 +210,29 @@ class Chef
         if addresses[network_name]
           return addresses[network_name].last['addr']
         end
+      end
+
+      def status_color(status)
+        case status
+          when 'shutting-down','terminated','stopping','stopped','error','shutoff','available'
+            ui.color(status, :red)
+          when 'pending','build','paused','suspended','hard_reboot'
+            ui.color(status, :yellow)
+          else
+            ui.color(status, :green)
+          end
+      end
+
+      def get_server_by_id(server_id)
+        # create server list
+        if @server_cache.nil?
+          @server_cache = {}
+          connection.servers.each do |s|
+            @server_cache[s.id] = s.name
+          end
+        end
+
+        @server_cache[server_id]
       end
 
     end

--- a/lib/chef/knife/openstack_volume_list.rb
+++ b/lib/chef/knife/openstack_volume_list.rb
@@ -1,0 +1,82 @@
+#
+# Author:: Florin STAN (<florin.stan@gmail.com>)
+# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife/openstack_base'
+
+class Chef
+  class Knife
+    class OpenstackVolumeList < Knife
+
+      include Knife::OpenstackBase
+
+      banner "knife openstack volume list (options)"
+
+      option :os_module,
+        :long => '--os-module (Nova|Cinder)',
+        :description => 'Openstack API That is going to be used. Default is Nova',
+        :default => 'Nova',
+        :require => false
+
+
+      def run
+        validate!
+
+        volume_list = [
+          ui.color('ID', :bold),
+          ui.color('Name', :bold),
+          ui.color('Status', :bold),
+          ui.color('Zone', :bold),
+          ui.color('Device', :bold),
+          ui.color('Attached to Server', :bold),
+        ]
+
+        target = locate_config_value(:os_module)
+        c = storage(target)
+
+        begin
+          vol_list = c.volumes.sort_by(&:name) if 'Nova' == target
+          vol_list = c.volumes.sort_by(&:display_name) if 'Cinder' == target
+          vol_list.each do |volume|
+            volume_list << volume.id.to_s
+            if defined? volume.name
+              volume_list << volume.name
+            else
+              volume_list << volume.display_name
+            end
+            volume_list << status_color(volume.status)
+            volume_list << volume.availability_zone
+            if volume.attachments.size > 0
+              volume_list << volume.attachments[0]["device"]
+              volume_list << get_server_by_id(volume.attachments[0]["server_id"]) if 'Cinder' == target
+              volume_list << get_server_by_id(volume.attachments[0]["serverId"]) if 'Nova' == target
+            else
+              volume_list << ""
+              volume_list << ""
+            end
+          end
+        rescue  Excon::Errors::BadRequest => e
+          response = Chef::JSONCompat.from_json(e.response.body)
+          ui.fatal("Unknown server error (#{response['badRequest']['code']}): #{response['badRequest']['message']}")
+          raise e
+        end
+        puts ui.list(volume_list, :uneven_columns_across, 6)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Added `knife openstack volume list` command.

It adds an command line options `--os-module (Nova|Cinder)` if you want to 
specify which Fog connection should be used to obtain the list of volumes. Default is Nova 