### PR TITLE
Add Fog dependency  to the Gemspec

### DIFF
--- a/knife-openstack.gemspec
+++ b/knife-openstack.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_dependency "fog", ">= 1.10.0"
   s.add_dependency "chef", ">= 0.10.10"
   s.add_dependency "knife-cloud"
 


### PR DESCRIPTION
Added runtime fog dependency.
These changes are depends  on knife-cloud changes: https://github.com/opscode/knife-cloud/pull/79
@muktaa 
