### PR TITLE
support multi region.

### DIFF
--- a/lib/chef/knife/cloud/openstack_service.rb
+++ b/lib/chef/knife/cloud/openstack_service.rb
@@ -26,6 +26,7 @@ class Chef
                                 :openstack_auth_url => Chef::Config[:knife][:openstack_auth_url],
                                 :openstack_endpoint_type => Chef::Config[:knife][:openstack_endpoint_type],
                                 :openstack_tenant => Chef::Config[:knife][:openstack_tenant],
+                                :openstack_region => Chef::Config[:knife][:openstack_region],
                                 :connection_options => {
                                   :ssl_verify_peer => !Chef::Config[:knife][:openstack_insecure]
                                 }


### PR DESCRIPTION
I enable you to use knife-openstack on multi region OpenStack.

if you write knife.rb such as ...

    knife[:openstack_region] = "region-b.geo-1"

you can specify region name.
I tested on Helion OpenStack.

Thanks from Tokyo.