### PR TITLE
remove deprecated 1.9 support and add 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.2
+  - 2.2.0
 
 script: bundle exec rake spec


### PR DESCRIPTION
It seems like most chef products have moved away from 1.9 support. Also it looks like there are some problems with installing gems in the build history. I'm hoping this fixes the travis testing.