### PR TITLE
Fix cloud command class loading

### DIFF
--- a/lib/chef/knife/openstack_floating_ip_allocate.rb
+++ b/lib/chef/knife/openstack_floating_ip_allocate.rb
@@ -3,6 +3,7 @@
 
 require 'chef/knife/openstack_helpers'
 require 'chef/knife/cloud/openstack_service_options'
+require 'chef/knife/cloud/command'
 
 class Chef
   class Knife

--- a/lib/chef/knife/openstack_floating_ip_associate.rb
+++ b/lib/chef/knife/openstack_floating_ip_associate.rb
@@ -4,6 +4,7 @@
 require 'chef/knife/openstack_helpers'
 require 'chef/knife/cloud/openstack_service_options'
 require 'chef/knife/cloud/openstack_service'
+require 'chef/knife/cloud/command'
 
 class Chef
   class Knife

--- a/lib/chef/knife/openstack_floating_ip_disassociate.rb
+++ b/lib/chef/knife/openstack_floating_ip_disassociate.rb
@@ -4,6 +4,7 @@
 require 'chef/knife/openstack_helpers'
 require 'chef/knife/cloud/openstack_service_options'
 require 'chef/knife/cloud/openstack_service'
+require 'chef/knife/cloud/command'
 
 class Chef
   class Knife

--- a/lib/chef/knife/openstack_floating_ip_release.rb
+++ b/lib/chef/knife/openstack_floating_ip_release.rb
@@ -2,9 +2,10 @@
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
 # Copyright:: Copyright (c) 2015 Chef Software, Inc.
 #
-\
+
 require 'chef/knife/openstack_helpers'
 require 'chef/knife/cloud/openstack_service_options'
+require 'chef/knife/cloud/command'
 
 class Chef
   class Knife


### PR DESCRIPTION
floating ip commands need to load chef/knife/cloud/command in case they are loaded first as noted in #172 