### PR TITLE
Fixed ip addresses not visible issue

### DIFF
--- a/lib/chef/knife/openstack_helpers.rb
+++ b/lib/chef/knife/openstack_helpers.rb
@@ -14,7 +14,7 @@ class Chef
         end
 
         def primary_network_ip_address(addresses, network_name)
-          return addresses[network_name].last['addr'] if addresses[network_name] && !addresses[network_name].empty?
+          addresses[network_name].last['addr'] if addresses[network_name] && !addresses[network_name].empty?
         end
 
         def create_service_instance
@@ -23,6 +23,19 @@ class Chef
 
         def validate!
           super(:openstack_username, :openstack_password, :openstack_auth_url)
+        end
+
+        def instance_addresses(addresses)
+          info = []
+          if addresses[addresses.keys[0]] && addresses[addresses.keys[0]].size > 0
+            ips = addresses[addresses.keys[0]]
+            ips.each do |ip|
+              version = 'IPv6' if ip['version'] == 6
+              version = 'IPv4' if ip['version'] == 4
+              info << "#{addresses.keys[0]}:#{version}: #{ip['addr']}"
+            end
+          end
+          info.join(' ')
         end
       end
     end

--- a/lib/chef/knife/openstack_server_list.rb
+++ b/lib/chef/knife/openstack_server_list.rb
@@ -35,34 +35,28 @@ class Chef
         banner "knife openstack server list (options)"
 
         def before_exec_command
-          #set columns_with_info map
+          # set columns_with_info map
           @columns_with_info = [
             {:label => 'Name', :key => 'name'},
             {:label => 'Instance ID', :key => 'id'},
-            {:label => 'Public IP', :key => 'addresses', :value_callback => method(:get_public_ip_address)},
-            {:label => 'Private IP', :key => 'addresses', :value_callback => method(:get_private_ip_address)},
+            {:label => 'Addresses', :key => 'addresses', :value_callback => method(:addresses)},
             {:label => 'Flavor', :key => 'flavor', :value_callback => method(:get_id)},
             {:label => 'Image', :key => 'image', :value_callback => method(:get_id)},
             {:label => 'Keypair', :key => 'key_name'},
             {:label => 'State', :key => 'state'},
             {:label => 'Availability Zone', :key => 'availability_zone'}
           ]
-          @sort_by_field = "name"
+          @sort_by_field = 'name'
           super
         end
 
-        def get_public_ip_address (addresses)
-          primary_public_ip_address(addresses)
-        end
-
-        def get_private_ip_address (addresses)
-          primary_private_ip_address(addresses)
+        def addresses(addresses)
+          instance_addresses(addresses)
         end
 
         def get_id(value)
           value['id']
         end
-
       end
     end
   end

--- a/lib/chef/knife/openstack_server_show.rb
+++ b/lib/chef/knife/openstack_server_show.rb
@@ -37,8 +37,7 @@ class Chef
           @columns_with_info = [
           {:label => 'Instance ID', :key => 'id'},
           {:label => 'Name', :key => 'name'},
-          {:label => 'Public IP', :key => 'addresses', :value_callback => method(:primary_public_ip_address)},
-          {:label => 'Private IP', :key => 'addresses', :value_callback => method(:primary_private_ip_address)},
+          {:label => 'Addresses', :key => 'addresses', :value_callback => method(:instance_addresses)},
           {:label => 'Flavor', :key => 'flavor', :value_callback => method(:get_id)},
           {:label => 'Image', :key => 'image', :value_callback => method(:get_id)},
           {:label => 'Keypair', :key => 'key_name'},


### PR DESCRIPTION
REF: https://github.com/chef/knife-openstack/issues/175 

This fix is according to response which I am getting from two different openstack account for server list command .

Following are two different responses

1) addresses={"public-120"=>[{"OS-EXT-IPS-MAC:mac_addr"=>"<mac-address>", "version"=>6, "addr"=>"<ipv6address>", "OS-EXT-IPS:type"=>"fixed"}

2) addresses={"public"=>[{"version"=>4, "addr"=>"<ip4address>"}]},

So to make the things generic I am displaying addresses with Addresses column with value name:version: ipaddress for e.g. 
for no. 1 response it will show output 'Addresses' as public-120:IPv6: <ip6address>
and for no. 2 it will show it as public:IPv4: <ip4address>
