### PR TITLE
Support all Fog OpenStack options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ In order to communicate with an OpenStack API you will need to tell Knife your O
     knife[:openstack_tenant] = "Your OpenStack tenant name"
     knife[:openstack_region] = "Your OpenStack Region"
 
+All of Fog's `openstack` options (`openstack_domain_name`, `openstack_project_name`, ...) are supported. This includes support for the OpenStack Identity v3 API.
+
 If your knife.rb file will be checked into a SCM system (ie readable by others) you may want to read the values from environment variables.  For example, using the conventions of [OpenStack's RC file](http://docs.openstack.org/user-guide/content/cli_openrc.html) (note the `openstack_auth_url`):
 
     knife[:openstack_auth_url] = "#{ENV['OS_AUTH_URL']}/tokens"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ In order to communicate with an OpenStack API you will need to tell Knife your O
     knife[:openstack_tenant] = "Your OpenStack tenant name"
     knife[:openstack_region] = "Your OpenStack Region"
 
-All of Fog's `openstack` options (`openstack_domain_name`, `openstack_project_name`, ...) are supported. This includes support for the OpenStack Identity v3 API.
+All of Fog's `openstack` options (`openstack_domain_name`, `openstack_project_name`, ...) are supported. This includes support for the OpenStack Identity v3 API:
+
+    knife[:openstack_auth_url] = "http://cloud.mycompany.com:5000/v3/auth/tokens"
+    knife[:openstack_username] = "Your OpenStack Dashboard username"
+    knife[:openstack_password] = "Your OpenStack Dashboard password"
+    knife[:openstack_project_name] = "Your OpenStack project"
+    knife[:openstack_domain_name] = "Your OpenStack domain"
 
 If your knife.rb file will be checked into a SCM system (ie readable by others) you may want to read the values from environment variables.  For example, using the conventions of [OpenStack's RC file](http://docs.openstack.org/user-guide/content/cli_openrc.html) (note the `openstack_auth_url`):
 

--- a/spec/functional/server_create_func_spec.rb
+++ b/spec/functional/server_create_func_spec.rb
@@ -75,7 +75,7 @@ describe Chef::Knife::Cloud::OpenstackServerCreate do
 
     context 'for Linux' do
       before do
-        @config = { openstack_floating_ip: '-1', bootstrap_ip_address: '75.101.253.10', ssh_password: 'password' }
+        @config = { openstack_floating_ip: '-1', bootstrap_ip_address: '75.101.253.10', ssh_password: 'password', hints: { "openstack" => {} }}
         @knife_openstack_create.config[:distro] = 'chef-full'
         @bootstrapper = Chef::Knife::Cloud::Bootstrapper.new(@config)
         @ssh_bootstrap_protocol = Chef::Knife::Cloud::SshBootstrapProtocol.new(@config)
@@ -95,7 +95,7 @@ describe Chef::Knife::Cloud::OpenstackServerCreate do
 
     context 'for Windows' do
       before do
-        @config = { openstack_floating_ip: '-1', image_os_type: 'windows', bootstrap_ip_address: '75.101.253.10', bootstrap_protocol: 'winrm', ssh_password: 'password' }
+        @config = { openstack_floating_ip: '-1', image_os_type: 'windows', bootstrap_ip_address: '75.101.253.10', bootstrap_protocol: 'winrm', ssh_password: 'password', hints: { "openstack" => {} } }
         @knife_openstack_create.config[:image_os_type] = 'windows'
         @knife_openstack_create.config[:bootstrap_protocol] = 'winrm'
         @knife_openstack_create.config[:distro] = 'windows-chef-client-msi'

--- a/spec/functional/server_list_func_spec.rb
+++ b/spec/functional/server_list_func_spec.rb
@@ -39,9 +39,10 @@ describe Chef::Knife::Cloud::OpenstackServerList do
     end
 
     it 'lists formatted list of resources' do
-      expect(instance.ui).to receive(:list).with(['Name', 'Instance ID', 'Public IP', 'Private IP', 'Flavor', 'Image', 'Keypair', 'State', 'Availability Zone',
-                                                  'ubuntu01', 'resource-1', '172.31.6.132', '172.31.6.133', '1', 'image1', 'keypair', 'ACTIVE', 'test zone',
-                                                  'windows2008', 'resource-2', '172.31.6.132', nil, 'id2', 'image2', 'keypair', 'ACTIVE', 'test zone', 'windows2008', 'resource-3-err', nil, nil, 'id2', 'image2', 'keypair', 'ERROR', 'test zone'], :uneven_columns_across, 9)
+      expect(instance.ui).to receive(:list).with(['Name', 'Instance ID', 'Addresses', 'Flavor', 'Image', 'Keypair', 'State', 'Availability Zone',
+                                                  'ubuntu01', 'resource-1', 'public:IPv4: 172.31.6.132', '1', 'image1', 'keypair', 'ACTIVE', 'test zone',
+                                                  'windows2008', 'resource-2', 'public:IPv4: 172.31.6.132', 'id2', 'image2', 'keypair', 'ACTIVE', 'test zone',
+                                                  'windows2008', 'resource-3-err', '', 'id2', 'image2', 'keypair', 'ERROR', 'test zone'], :uneven_columns_across, 8)
       instance.run
     end
 
@@ -54,22 +55,22 @@ describe Chef::Knife::Cloud::OpenstackServerList do
       end
 
       it 'lists formatted list of resources on chef data option set' do
-        expect(instance.ui).to receive(:list).with(['Name', 'Instance ID', 'Public IP', 'Private IP', 'Flavor', 'Image', 'Keypair', 'State', 'Availability Zone', 'Chef Node Name', 'Environment', 'FQDN', 'Runlist', 'Tags', 'Platform',
-                                                    'server-4', 'server-4', '172.31.6.132', '172.31.6.133', '1', 'image1', 'keypair', 'ACTIVE', 'test zone', 'server-4', '_default', 'testfqdnnode.us', '[]', '[]', 'ubuntu',
-                                                    'ubuntu01', 'resource-1', '172.31.6.132', '172.31.6.133', '1', 'image1', 'keypair', 'ACTIVE', 'test zone', '', '', '', '', '', '',
-                                                    'windows2008', 'resource-2', '172.31.6.132', nil, 'id2', 'image2', 'keypair', 'ACTIVE', 'test zone', '', '', '', '', '', '',
-                                                    'windows2008', 'resource-3-err', nil, nil, 'id2', 'image2', 'keypair', 'ERROR', 'test zone', '', '', '', '', '', ''], :uneven_columns_across, 15)
+        expect(instance.ui).to receive(:list).with(['Name', 'Instance ID', 'Addresses', 'Flavor', 'Image', 'Keypair', 'State', 'Availability Zone', 'Chef Node Name', 'Environment', 'FQDN', 'Runlist', 'Tags', 'Platform',
+                                                    'server-4', 'server-4', 'public:IPv4: 172.31.6.132', '1', 'image1', 'keypair', 'ACTIVE', 'test zone', 'server-4', '_default', 'testfqdnnode.us', '[]', '[]', 'ubuntu',
+                                                    'ubuntu01', 'resource-1', 'public:IPv4: 172.31.6.132', '1', 'image1', 'keypair', 'ACTIVE', 'test zone', '', '', '', '', '', '',
+                                                    'windows2008', 'resource-2', 'public:IPv4: 172.31.6.132', 'id2', 'image2', 'keypair', 'ACTIVE', 'test zone', '', '', '', '', '', '',
+                                                    'windows2008', 'resource-3-err', '', 'id2', 'image2', 'keypair', 'ERROR', 'test zone', '', '', '', '', '', ''], :uneven_columns_across, 14)
         instance.run
       end
 
       it 'lists formatted list of resources on chef-data and chef-node-attribute option set' do
         instance.config[:chef_node_attribute] = 'platform_family'
         expect(@node).to receive(:attribute?).with('platform_family').and_return(true)
-        expect(instance.ui).to receive(:list).with(['Name', 'Instance ID', 'Public IP', 'Private IP', 'Flavor', 'Image', 'Keypair', 'State', 'Availability Zone', 'Chef Node Name', 'Environment', 'FQDN', 'Runlist', 'Tags', 'Platform', 'platform_family',
-                                                    'server-4', 'server-4', '172.31.6.132', '172.31.6.133', '1', 'image1', 'keypair', 'ACTIVE', 'test zone', 'server-4', '_default', 'testfqdnnode.us', '[]', '[]', 'ubuntu', 'debian',
-                                                    'ubuntu01', 'resource-1', '172.31.6.132', '172.31.6.133', '1', 'image1', 'keypair', 'ACTIVE', 'test zone', '', '', '', '', '', '', '',
-                                                    'windows2008', 'resource-2', '172.31.6.132', nil, 'id2', 'image2', 'keypair', 'ACTIVE', 'test zone', '', '', '', '', '', '', '',
-                                                    'windows2008', 'resource-3-err', nil, nil, 'id2', 'image2', 'keypair', 'ERROR', 'test zone', '', '', '', '', '', '', ''], :uneven_columns_across, 16)
+        expect(instance.ui).to receive(:list).with(['Name', 'Instance ID', 'Addresses', 'Flavor', 'Image', 'Keypair', 'State', 'Availability Zone', 'Chef Node Name', 'Environment', 'FQDN', 'Runlist', 'Tags', 'Platform', 'platform_family',
+                                                    'server-4', 'server-4', 'public:IPv4: 172.31.6.132', '1', 'image1', 'keypair', 'ACTIVE', 'test zone', 'server-4', '_default', 'testfqdnnode.us', '[]', '[]', 'ubuntu', 'debian',
+                                                    'ubuntu01', 'resource-1', 'public:IPv4: 172.31.6.132', '1', 'image1', 'keypair', 'ACTIVE', 'test zone', '', '', '', '', '', '', '',
+                                                    'windows2008', 'resource-2', 'public:IPv4: 172.31.6.132', 'id2', 'image2', 'keypair', 'ACTIVE', 'test zone', '', '', '', '', '', '', '',
+                                                    'windows2008', 'resource-3-err', '', 'id2', 'image2', 'keypair', 'ERROR', 'test zone', '', '', '', '', '', '', ''], :uneven_columns_across, 15)
         instance.run
       end
 
@@ -84,11 +85,11 @@ describe Chef::Knife::Cloud::OpenstackServerList do
       it 'not display chef-data on chef-node-attribute set but chef-data option missing' do
         instance.config[:chef_data] = false
         instance.config[:chef_node_attribute] = 'platform_family'
-        expect(instance.ui).to receive(:list).with(['Name', 'Instance ID', 'Public IP', 'Private IP', 'Flavor', 'Image', 'Keypair', 'State', 'Availability Zone',
-                                                    'server-4', 'server-4', '172.31.6.132', '172.31.6.133', '1', 'image1', 'keypair', 'ACTIVE', 'test zone',
-                                                    'ubuntu01', 'resource-1', '172.31.6.132', '172.31.6.133', '1', 'image1', 'keypair', 'ACTIVE', 'test zone',
-                                                    'windows2008', 'resource-2', '172.31.6.132', nil, 'id2', 'image2', 'keypair', 'ACTIVE', 'test zone',
-                                                    'windows2008', 'resource-3-err', nil, nil, 'id2', 'image2', 'keypair', 'ERROR', 'test zone'], :uneven_columns_across, 9)
+        expect(instance.ui).to receive(:list).with(['Name', 'Instance ID', 'Addresses', 'Flavor', 'Image', 'Keypair', 'State', 'Availability Zone',
+                                                    'server-4', 'server-4', 'public:IPv4: 172.31.6.132', '1', 'image1', 'keypair', 'ACTIVE', 'test zone',
+                                                    'ubuntu01', 'resource-1', 'public:IPv4: 172.31.6.132', '1', 'image1', 'keypair', 'ACTIVE', 'test zone',
+                                                    'windows2008', 'resource-2', 'public:IPv4: 172.31.6.132', 'id2', 'image2', 'keypair', 'ACTIVE', 'test zone',
+                                                    'windows2008', 'resource-3-err', '', 'id2', 'image2', 'keypair', 'ERROR', 'test zone'], :uneven_columns_across, 8)
         instance.run
       end
     end

--- a/spec/unit/openstack_server_create_spec.rb
+++ b/spec/unit/openstack_server_create_spec.rb
@@ -148,7 +148,7 @@ describe Chef::Knife::Cloud::OpenstackServerCreate do
 
     it 'ensures default value for metadata' do
       options = @instance.options
-      expect(options[:metadata][:default]).to be.nil?
+      expect(options[:metadata][:default]).to be_nil
     end
   end
 

--- a/spec/unit/openstack_service_spec.rb
+++ b/spec/unit/openstack_service_spec.rb
@@ -33,21 +33,21 @@ describe Chef::Knife::Cloud::OpenstackService do
     end
 
     it 'sets the api_endpoint in auth params' do
-      expect(@instance.instance_variable_get(:@auth_params)[:openstack_auth_url]).to be.nil?
+      expect(@instance.instance_variable_get(:@auth_params)[:openstack_auth_url]).to be_nil
       @instance.add_api_endpoint
       expect(@instance.instance_variable_get(:@auth_params)[:openstack_auth_url]).to be == @api_endpoint
     end
 
     it 'does not set the endpoint when --api-endpoint option is missing' do
       Chef::Config[:knife][:api_endpoint] = nil
-      expect(@instance.instance_variable_get(:@auth_params)[:openstack_auth_url]).to be.nil?
+      expect(@instance.instance_variable_get(:@auth_params)[:openstack_auth_url]).to be_nil
       @instance.add_api_endpoint
       expect(@instance.instance_variable_get(:@auth_params)[:openstack_auth_url]).to_not be == @api_endpoint
-      expect(@instance.instance_variable_get(:@auth_params)[:openstack_auth_url]).to be.nil?
+      expect(@instance.instance_variable_get(:@auth_params)[:openstack_auth_url]).to be_nil
     end
 
     it "doesn't set an OpenStack endpoint type by default" do
-      expect(Chef::Config[:knife][:openstack_endpoint_type]).to be.nil?
+      expect(Chef::Config[:knife][:openstack_endpoint_type]).to be_nil
     end
   end
 


### PR DESCRIPTION
This loads all the `openstack` options directly from Fog to create `auth_params`. The only deviations from Fog are the two that existed previously, `openstack_insecure` and `openstack_password`.