### PR TITLE
Add Expeditor + Cleanup test deps, Rake tasks, and add chefstyle testing

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,0 +1,43 @@
+# Documentation available at https://expeditor.chef.io/docs/getting-started/
+---
+# Slack channel in Chef Software slack to send notifications about build failures, etc
+slack:
+  notify_channel:
+    - sustaining-notify
+    - chef-notify
+
+# This publish is triggered by the `built_in:publish_rubygems` artifact_action.
+rubygems:
+  - knife-openstack
+
+github:
+  # This deletes the GitHub PR branch after successfully merged into the release branch
+  delete_branch_on_merge: true
+  # The tag format to use (e.g. v1.0.0)
+  version_tag_format: "win32-eventlog-{{version}}"
+  # allow bumping the minor release via label
+  minor_bump_labels:
+    - "Expeditor: Bump Minor Version"
+
+changelog:
+  rollup_header: Changes not yet released to rubygems.org
+
+# These actions are taken, in order they are specified, anytime a Pull Request is merged.
+merge_actions:
+  - built_in:bump_version:
+      ignore_labels:
+        - "Expeditor: Skip Version Bump"
+        - "Expeditor: Skip All"
+  - bash:.expeditor/update_version.sh:
+      only_if: built_in:bump_version
+  - built_in:update_changelog:
+      ignore_labels:
+        - "Expeditor: Exclude From Changelog"
+        - "Expeditor: Skip All"
+  - built_in:build_gem:
+      only_if: built_in:bump_version
+
+promote:
+  actions:
+    - built_in:rollover_changelog
+    - built_in:publish_rubygems

--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# After a PR merge, Chef Expeditor will bump the PATCH version in the VERSION file.
+# It then executes this file to update any other files/components with that new version.
+#
+
+set -evx
+
+sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" lib/win32/eventlog.rb
+
+# Once Expeditor finshes executing this script, it will commit the changes and push
+# the commit as a new tag corresponding to the value in the VERSION file.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 ### Issues Resolved
 
 [List any existing issues this PR resolves, or any Discourse or
-StackOverflow discussion that's relevant]
+StackOverflow discussions that are relevant]
 
 ### Check List
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,18 @@
 *.gem
-.bundle
-.rvmrc
-Gemfile.lock
+
 .autotest
 coverage
 .DS_Store
 pkg
 */tags
+*~
+
+# you should check in your Gemfile.lock in applications, and not in gems
+Gemfile.lock
+Gemfile.local
+
+# Do not check in the .bundle directory, or any of the files inside it. Those files are specific to each particular machine, and are used to persist installation options between runs of the bundle install command.
+.bundle
 
 # ignore some common Bundler 'binstubs' directory names
 # http://gembundler.com/man/bundle-exec.1.html
@@ -28,5 +34,5 @@ _site/*
 doc/
 pkg/*
 
-#keys
+# keys
 *.pem

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,29 @@
+# Configuration parameters: AllowSafeAssignment.
+Lint/AssignmentInCondition:
+  Exclude:
+    - 'lib/chef/knife/cloud/openstack_service.rb'
+
+Lint/ParenthesesAsGroupedExpression:
+  Exclude:
+    - 'spec/functional/flavor_list_func_spec.rb'
+    - 'spec/functional/floating_ip_list_func_spec.rb'
+    - 'spec/functional/group_list_func_spec.rb'
+    - 'spec/functional/image_list_func_spec.rb'
+    - 'spec/functional/network_list_func_spec.rb'
+    - 'spec/functional/server_list_func_spec.rb'
+    - 'spec/functional/volume_list_func_spec.rb'
+    - 'spec/unit/openstack_group_list_spec.rb'
+    - 'spec/unit/openstack_image_list_spec.rb'
+    - 'spec/unit/openstack_network_list_spec.rb'
+    - 'spec/unit/openstack_server_delete_spec.rb'
+    - 'spec/unit/openstack_server_list_spec.rb'
+    - 'spec/unit/openstack_server_show_spec.rb'
+    - 'spec/unit/openstack_service_spec.rb'
+
+Lint/UselessAssignment:
+  Exclude:
+    - 'lib/chef/knife/openstack_floating_ip_disassociate.rb'
+    - 'lib/chef/knife/openstack_server_create.rb'
+    - 'spec/integration/openstack_spec.rb'
+    - 'spec/spec_helper.rb'
+    - 'spec/unit/openstack_floating_ip_release_spec.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: bundler
 
 matrix:
   include:
-    - rvm: 2.2.10
     - rvm: 2.3.7
     - rvm: 2.4.4
     - rvm: 2.5.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,7 @@ branches:
     - master
 
 bundler_args: --jobs 7 --without docs debug
-script: bundle exec rake
+
+script:
+  - bundle exec chefstyle
+  - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
+sudo: false
 language: ruby
 cache: bundler
-dist: trusty
-sudo: false
-rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-  - ruby-head
-  
+
 matrix:
+  include:
+    - rvm: 2.2.10
+    - rvm: 2.3.7
+    - rvm: 2.4.4
+    - rvm: 2.5.1
+    - rvm: ruby-head
   allow_failures:
     - rvm: ruby-head
 
 branches:
   only:
     - master
+
+bundler_args: --jobs 7 --without docs debug
 script: bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
-# Change Log
+# knife-openstack Change Log
 
+<!-- latest_release -->
+<!-- latest_release -->
+<!-- release_rollup -->
+<!-- release_rollup -->
+<!-- latest_stable_release -->
 ## [2.1.0](https://github.com/chef/knife-openstack/tree/2.1.0) (2017-08-21)
 [Full Changelog](https://github.com/chef/knife-openstack/compare/v2.0.1...2.1.0)
 
 **Merged pull requests:**
 
 - Test on the latest Ruby releases in Travis [\#202](https://github.com/chef/knife-openstack/pull/202) ([tas50](https://github.com/tas50))
+<!-- latest_stable_release -->
 
 ## [v2.0.1](https://github.com/chef/knife-openstack/tree/v2.0.1) (2017-03-21)
 [Full Changelog](https://github.com/chef/knife-openstack/compare/v2.0.0...v2.0.1)

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,33 @@
-# frozen_string_literal: true
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in knife-openstack.gemspec
 gemspec
+
+group :docs do
+  gem "github-markup"
+  gem "redcarpet"
+  gem "yard"
+end
+
+group :test do
+  gem "chefstyle", "= 0.10.0"
+  gem "guard-rspec"
+  gem "mixlib-shellout"
+  gem "rake"
+  gem "rspec", "~> 3.0"
+  gem "rspec-expectations"
+  gem "rspec-mocks"
+  gem "rspec_junit_formatter"
+end
+
+group :debug do
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-stack_explorer"
+  gem "rb-readline"
+end
+
+instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
+
+# If you want to load debugging tools into the bundle exec sandbox,
+# add these additional dependencies into Gemfile.local
+eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Author:: Chirag Jog ([chirag@clogeny.com](mailto:chirag@clogeny.com))
 
 Author:: JJ Asghar ([jj@chef.io](mailto:jj@chef.io))
 
-Copyright:: Copyright (c) 2011-2016 Chef Software, Inc.
+Copyright:: Copyright 2011-2018 Chef Software, Inc.
 
 License:: Apache License, Version 2.0
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # Author:: Kaustubh Deorukhkar (<kaustubh@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2016 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 
 require "bundler/setup"
 require "bundler/gem_tasks"

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 # Author:: Kaustubh Deorukhkar (<kaustubh@clogeny.com>)
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,14 +2,11 @@
 # Author:: Kaustubh Deorukhkar (<kaustubh@clogeny.com>)
 # Copyright:: Copyright (c) 2013-2016 Chef Software, Inc.
 
-require "bundler"
 require "bundler/setup"
 require "bundler/gem_tasks"
 require "chefstyle"
 require "rubocop/rake_task"
 require "rspec/core/rake_task"
-require "github_changelog_generator/task"
-require "knife-openstack/version"
 
 RuboCop::RakeTask.new
 
@@ -18,12 +15,15 @@ RSpec::Core::RakeTask.new(:spec)
 task default: [:rubocop, :spec]
 
 begin
-  require "github_changelog_generator/task"
-
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = Knife::OpenStack::VERSION
-    config.issues = true
-  end
+  require "yard"
+  YARD::Rake::YardocTask.new(:docs)
 rescue LoadError
-  puts "github_changelog_generator is not available. gem install github_changelog_generator to generate changelogs"
+  puts "yard is not available. bundle install first to make sure all dependencies are installed."
+end
+
+task :console do
+  require "irb"
+  require "irb/completion"
+  ARGV.clear
+  IRB.start
 end

--- a/knife-openstack.gemspec
+++ b/knife-openstack.gemspec
@@ -28,14 +28,4 @@ Gem::Specification.new do |s|
   s.add_dependency "chef", ">= 12"
   s.add_dependency "knife-cloud", "~> 1.2.0"
 
-  s.add_development_dependency "chefstyle"
-  s.add_development_dependency "github_changelog_generator"
-  s.add_development_dependency "guard-rspec"
-  s.add_development_dependency "mixlib-shellout"
-  s.add_development_dependency "rake"
-  s.add_development_dependency "rspec", "~> 3.0"
-  s.add_development_dependency "rspec-expectations"
-  s.add_development_dependency "rspec-mocks"
-  s.add_development_dependency "rspec_junit_formatter"
-
 end

--- a/knife-openstack.gemspec
+++ b/knife-openstack.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-# frozen_string_literal: true
+#
 $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 require "knife-openstack/version"
 

--- a/knife-openstack.gemspec
+++ b/knife-openstack.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.2"
 
   s.add_dependency "fog", "~> 1.23"
-  s.add_dependency "chef", ">= 12"
+  s.add_dependency "chef", ">= 13"
   s.add_dependency "knife-cloud", "~> 1.2.0"
 
 end

--- a/knife-openstack.gemspec
+++ b/knife-openstack.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = ">= 2.2.2"
+  s.required_ruby_version = ">= 2.3"
 
   s.add_dependency "fog", "~> 1.23"
   s.add_dependency "chef", ">= 13"

--- a/lib/chef/knife/cloud/openstack_server_create_options.rb
+++ b/lib/chef/knife/cloud/openstack_server_create_options.rb
@@ -1,5 +1,20 @@
+#
+# Copyright:: Copyright 2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-# frozen_string_literal: true
 require "chef/knife/cloud/server/create_options"
 
 class Chef

--- a/lib/chef/knife/cloud/openstack_service.rb
+++ b/lib/chef/knife/cloud/openstack_service.rb
@@ -2,7 +2,20 @@
 #
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Kaustubh Deorukhkar (<kaustubh@clogeny.com>)
-# Copyright:: Copyright (c) 2013 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 require "chef/knife/cloud/fog/service"

--- a/lib/chef/knife/cloud/openstack_service.rb
+++ b/lib/chef/knife/cloud/openstack_service.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Kaustubh Deorukhkar (<kaustubh@clogeny.com>)

--- a/lib/chef/knife/cloud/openstack_service_options.rb
+++ b/lib/chef/knife/cloud/openstack_service_options.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 # Copyright:: Copyright 2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #

--- a/lib/chef/knife/cloud/openstack_service_options.rb
+++ b/lib/chef/knife/cloud/openstack_service_options.rb
@@ -1,4 +1,20 @@
 # frozen_string_literal: true
+# Copyright:: Copyright 2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require "chef/knife/cloud/fog/options"
 class Chef
   class Knife

--- a/lib/chef/knife/openstack_flavor_list.rb
+++ b/lib/chef/knife/openstack_flavor_list.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Copyright:: Copyright 2014-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0

--- a/lib/chef/knife/openstack_flavor_list.rb
+++ b/lib/chef/knife/openstack_flavor_list.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright 2014-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require "chef/knife/cloud/list_resource_command"
 require "chef/knife/openstack_helpers"

--- a/lib/chef/knife/openstack_floating_ip_allocate.rb
+++ b/lib/chef/knife/openstack_floating_ip_allocate.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
-# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# Copyright:: Copyright 2015-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require "chef/knife/openstack_helpers"
 require "chef/knife/cloud/openstack_service_options"

--- a/lib/chef/knife/openstack_floating_ip_allocate.rb
+++ b/lib/chef/knife/openstack_floating_ip_allocate.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
 # Copyright:: Copyright 2015-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0

--- a/lib/chef/knife/openstack_floating_ip_associate.rb
+++ b/lib/chef/knife/openstack_floating_ip_associate.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
 # Copyright:: Copyright 2015-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
@@ -44,7 +44,7 @@ class Chef
             exit 1
           end
 
-          response = @service.associate_address(instance_id, floating_ip)
+          response = @service.associate_address(locate_config_value(:instance_id), floating_ip)
           if response && response.status == 202
             ui.info "Floating IP #{floating_ip} associated with Instance #{locate_config_value(:instance_id)}"
           end

--- a/lib/chef/knife/openstack_floating_ip_associate.rb
+++ b/lib/chef/knife/openstack_floating_ip_associate.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
-# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# Copyright:: Copyright 2015-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require "chef/knife/openstack_helpers"
 require "chef/knife/cloud/openstack_service_options"

--- a/lib/chef/knife/openstack_floating_ip_disassociate.rb
+++ b/lib/chef/knife/openstack_floating_ip_disassociate.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
-# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# Copyright:: Copyright 2015-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require "chef/knife/openstack_helpers"
 require "chef/knife/cloud/openstack_service_options"

--- a/lib/chef/knife/openstack_floating_ip_disassociate.rb
+++ b/lib/chef/knife/openstack_floating_ip_disassociate.rb
@@ -44,8 +44,8 @@ class Chef
             exit 1
           end
 
+          response = @service.disassociate_address(locate_config_value(:instance_id), floating_ip)
           if response && response.status == 202
-            response = @service.disassociate_address(locate_config_value(:instance_id), floating_ip)
             ui.info "Floating IP #{floating_ip} disassociated with Instance #{locate_config_value(:instance_id)}"
           end
         end

--- a/lib/chef/knife/openstack_floating_ip_disassociate.rb
+++ b/lib/chef/knife/openstack_floating_ip_disassociate.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
 # Copyright:: Copyright 2015-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
@@ -45,7 +45,7 @@ class Chef
           end
 
           if response && response.status == 202
-            response = @service.disassociate_address(instance_id, floating_ip)
+            response = @service.disassociate_address(locate_config_value(:instance_id), floating_ip)
             ui.info "Floating IP #{floating_ip} disassociated with Instance #{locate_config_value(:instance_id)}"
           end
         end

--- a/lib/chef/knife/openstack_floating_ip_list.rb
+++ b/lib/chef/knife/openstack_floating_ip_list.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
 # Copyright:: Copyright 2015-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0

--- a/lib/chef/knife/openstack_floating_ip_list.rb
+++ b/lib/chef/knife/openstack_floating_ip_list.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
-# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# Copyright:: Copyright 2015-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require "chef/knife/cloud/list_resource_command"
 require "chef/knife/openstack_helpers"

--- a/lib/chef/knife/openstack_floating_ip_release.rb
+++ b/lib/chef/knife/openstack_floating_ip_release.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
 # Copyright:: Copyright 2015-2018 Chef Software, Inc.

--- a/lib/chef/knife/openstack_floating_ip_release.rb
+++ b/lib/chef/knife/openstack_floating_ip_release.rb
@@ -1,7 +1,20 @@
 # frozen_string_literal: true
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
-# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# Copyright:: Copyright 2015-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 require "chef/knife/openstack_helpers"

--- a/lib/chef/knife/openstack_group_list.rb
+++ b/lib/chef/knife/openstack_group_list.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 # Copyright:: Copyright 2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #

--- a/lib/chef/knife/openstack_group_list.rb
+++ b/lib/chef/knife/openstack_group_list.rb
@@ -18,6 +18,7 @@
 require "chef/knife/cloud/list_resource_command"
 require "chef/knife/openstack_helpers"
 require "chef/knife/cloud/openstack_service_options"
+require "chef/json_compat"
 
 class Chef
   class Knife

--- a/lib/chef/knife/openstack_group_list.rb
+++ b/lib/chef/knife/openstack_group_list.rb
@@ -1,4 +1,20 @@
 # frozen_string_literal: true
+# Copyright:: Copyright 2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require "chef/knife/cloud/list_resource_command"
 require "chef/knife/openstack_helpers"
 require "chef/knife/cloud/openstack_service_options"

--- a/lib/chef/knife/openstack_helpers.rb
+++ b/lib/chef/knife/openstack_helpers.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 # Copyright:: Copyright 2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #

--- a/lib/chef/knife/openstack_helpers.rb
+++ b/lib/chef/knife/openstack_helpers.rb
@@ -1,4 +1,20 @@
 # frozen_string_literal: true
+# Copyright:: Copyright 2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require "chef/knife/cloud/openstack_service_options"
 
 class Chef

--- a/lib/chef/knife/openstack_image_list.rb
+++ b/lib/chef/knife/openstack_image_list.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Copyright:: Copyright 2014-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0

--- a/lib/chef/knife/openstack_image_list.rb
+++ b/lib/chef/knife/openstack_image_list.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright 2014-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require "chef/knife/cloud/list_resource_command"
 require "chef/knife/openstack_helpers"

--- a/lib/chef/knife/openstack_network_list.rb
+++ b/lib/chef/knife/openstack_network_list.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Copyright:: Copyright 2014-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0

--- a/lib/chef/knife/openstack_network_list.rb
+++ b/lib/chef/knife/openstack_network_list.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright 2014-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require "chef/knife/cloud/list_resource_command"
 require "chef/knife/openstack_helpers"

--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #
 # Author:: Seth Chisamore (<schisamo@chef.io>)
 # Author:: Matt Ray (<matt@chef.io>)

--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 #
-# Author:: Seth Chisamore (<schisamo@getchef.com>)
-# Author:: Matt Ray (<matt@getchef.com>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Matt Ray (<matt@chef.io>)
 # Author:: Chirag Jog (<chirag@clogeny.com>)
-# Copyright:: Copyright (c) 2011-2014 Chef Software, Inc.
+# Copyright:: Copyright 2011-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/openstack_server_delete.rb
+++ b/lib/chef/knife/openstack_server_delete.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Kaustubh Deorukhkar (<kaustubh@clogeny.com>)

--- a/lib/chef/knife/openstack_server_delete.rb
+++ b/lib/chef/knife/openstack_server_delete.rb
@@ -2,7 +2,20 @@
 #
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Kaustubh Deorukhkar (<kaustubh@clogeny.com>)
-# Copyright:: Copyright (c) 2013 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 require "chef/knife/cloud/server/delete_options"

--- a/lib/chef/knife/openstack_server_list.rb
+++ b/lib/chef/knife/openstack_server_list.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #
 # Author:: Seth Chisamore (<schisamo@chef.io>)
 # Author:: Matt Ray (<matt@chef.io>)

--- a/lib/chef/knife/openstack_server_list.rb
+++ b/lib/chef/knife/openstack_server_list.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 #
-# Author:: Seth Chisamore (<schisamo@getchef.com>)
-# Author:: Matt Ray (<matt@getchef.com>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Matt Ray (<matt@chef.io>)
 # Author:: Chirag Jog (<chirag@clogeny.com>)
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
-# Copyright:: Copyright (c) 2011-2013 Chef Software, Inc.
+# Copyright:: Copyright 2011-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/openstack_server_show.rb
+++ b/lib/chef/knife/openstack_server_show.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #
 # Copyright:: Copyright 2011-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0

--- a/lib/chef/knife/openstack_server_show.rb
+++ b/lib/chef/knife/openstack_server_show.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-# Copyright:: Copyright (c) 2011-2013 Chef Software, Inc.
+# Copyright:: Copyright 2011-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/openstack_volume_list.rb
+++ b/lib/chef/knife/openstack_volume_list.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 #
-# Author:: Seth Chisamore (<schisamo@getchef.com>)
-# Author:: Matt Ray (<matt@getchef.com>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Matt Ray (<matt@chef.io>)
 # Author:: Evan Felix (<karcaw@gmail.com>)
-# Copyright:: Copyright (c) 2011-2014 Chef Software, Inc.
+# Copyright:: Copyright 2011-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/openstack_volume_list.rb
+++ b/lib/chef/knife/openstack_volume_list.rb
@@ -21,6 +21,7 @@
 require "chef/knife/cloud/list_resource_command"
 require "chef/knife/openstack_helpers"
 require "chef/knife/cloud/openstack_service_options"
+require "chef/json_compat"
 
 class Chef
   class Knife

--- a/lib/chef/knife/openstack_volume_list.rb
+++ b/lib/chef/knife/openstack_volume_list.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #
 # Author:: Seth Chisamore (<schisamo@chef.io>)
 # Author:: Matt Ray (<matt@chef.io>)

--- a/lib/knife-openstack/version.rb
+++ b/lib/knife-openstack/version.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 module Knife
   module OpenStack
     VERSION = "2.1.0"

--- a/spec/functional/flavor_list_func_spec.rb
+++ b/spec/functional/flavor_list_func_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)

--- a/spec/functional/flavor_list_func_spec.rb
+++ b/spec/functional/flavor_list_func_spec.rb
@@ -2,7 +2,7 @@
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/functional/floating_ip_list_func_spec.rb
+++ b/spec/functional/floating_ip_list_func_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/functional/floating_ip_list_func_spec.rb
+++ b/spec/functional/floating_ip_list_func_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.

--- a/spec/functional/group_list_func_spec.rb
+++ b/spec/functional/group_list_func_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)

--- a/spec/functional/group_list_func_spec.rb
+++ b/spec/functional/group_list_func_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/functional/image_list_func_spec.rb
+++ b/spec/functional/image_list_func_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)

--- a/spec/functional/image_list_func_spec.rb
+++ b/spec/functional/image_list_func_spec.rb
@@ -2,7 +2,7 @@
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/functional/network_list_func_spec.rb
+++ b/spec/functional/network_list_func_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright 2014-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/functional/network_list_func_spec.rb
+++ b/spec/functional/network_list_func_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
 # Copyright:: Copyright 2014-2018 Chef Software, Inc.

--- a/spec/functional/server_create_func_spec.rb
+++ b/spec/functional/server_create_func_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Kaustubh Deorukhkar (<kaustubh@clogeny.com>)

--- a/spec/functional/server_create_func_spec.rb
+++ b/spec/functional/server_create_func_spec.rb
@@ -5,7 +5,7 @@
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/functional/server_delete_func_spec.rb
+++ b/spec/functional/server_delete_func_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)

--- a/spec/functional/server_delete_func_spec.rb
+++ b/spec/functional/server_delete_func_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/functional/server_list_func_spec.rb
+++ b/spec/functional/server_list_func_spec.rb
@@ -4,7 +4,7 @@
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/functional/server_list_func_spec.rb
+++ b/spec/functional/server_list_func_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)

--- a/spec/functional/server_show_func_spec.rb
+++ b/spec/functional/server_show_func_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.

--- a/spec/functional/server_show_func_spec.rb
+++ b/spec/functional/server_show_func_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/functional/volume_list_func_spec.rb
+++ b/spec/functional/volume_list_func_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)

--- a/spec/functional/volume_list_func_spec.rb
+++ b/spec/functional/volume_list_func_spec.rb
@@ -2,7 +2,7 @@
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/integration/cleanup.rb
+++ b/spec/integration/cleanup.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-# Copyright: Copyright (c) 2013-2014 Chef Software, Inc.
+#
+# Copyright: Copyright 2013-2018 Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/integration/cleanup.rb
+++ b/spec/integration/cleanup.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #
 # Copyright: Copyright 2013-2018 Chef Software, Inc.
 # License: Apache License, Version 2.0

--- a/spec/integration/openstack_spec.rb
+++ b/spec/integration/openstack_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+#
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/integration/openstack_spec.rb
+++ b/spec/integration/openstack_spec.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License: Apache License, Version 2.0

--- a/spec/spec_context.rb
+++ b/spec/spec_context.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright 2014-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/spec_context.rb
+++ b/spec/spec_context.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Copyright:: Copyright 2014-2018 Chef Software, Inc.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+#
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License: Apache License, Version 2.0

--- a/spec/unit/openstack_flavor_list_spec.rb
+++ b/spec/unit/openstack_flavor_list_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_flavor_list_spec.rb
+++ b/spec/unit/openstack_flavor_list_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)

--- a/spec/unit/openstack_floating_ip_allocate_spec.rb
+++ b/spec/unit/openstack_floating_ip_allocate_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.

--- a/spec/unit/openstack_floating_ip_allocate_spec.rb
+++ b/spec/unit/openstack_floating_ip_allocate_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2015 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_floating_ip_associate_spec.rb
+++ b/spec/unit/openstack_floating_ip_associate_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.

--- a/spec/unit/openstack_floating_ip_associate_spec.rb
+++ b/spec/unit/openstack_floating_ip_associate_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2015 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 require "spec_helper"
 require "chef/knife/openstack_floating_ip_associate"
 require "chef/knife/cloud/openstack_service"

--- a/spec/unit/openstack_floating_ip_disassociate_spec.rb
+++ b/spec/unit/openstack_floating_ip_disassociate_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2015 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_floating_ip_disassociate_spec.rb
+++ b/spec/unit/openstack_floating_ip_disassociate_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.
@@ -30,8 +30,8 @@ describe Chef::Knife::Cloud::OpenstackFloatingIpDisassociate do
   describe "associate floating ip" do
     it "calls associate address" do
       @instance.service = Chef::Knife::Cloud::Service.new
-      response = OpenStruct.new(status: 202)
-      expect(@instance.service).to receive(:disassociate_address).with("23849038438240934n3294839248", "127.0.0.1").and_return(response)
+      @response = OpenStruct.new(status: 202)
+      expect(@instance.service).to receive(:disassociate_address).with("23849038438240934n3294839248", "127.0.0.1").and_return(@response)
       expect(@instance.ui).to receive(:info).and_return("Floating IP 127.0.0.1 disassociated with Instance 23849038438240934n3294839248")
       @instance.execute_command
     end

--- a/spec/unit/openstack_floating_ip_disassociate_spec.rb
+++ b/spec/unit/openstack_floating_ip_disassociate_spec.rb
@@ -30,8 +30,8 @@ describe Chef::Knife::Cloud::OpenstackFloatingIpDisassociate do
   describe "disassociate floating ip" do
     it "calls disassociate address" do
       @instance.service = Chef::Knife::Cloud::Service.new
-      @response = OpenStruct.new(status: 202)
-      expect(@instance.service).to receive(:disassociate_address).with("23849038438240934n3294839248", "127.0.0.1").and_return(@response)
+      response = OpenStruct.new(status: 202)
+      expect(@instance.service).to receive(:disassociate_address).with("23849038438240934n3294839248", "127.0.0.1").and_return(response)
       expect(@instance.ui).to receive(:info).and_return("Floating IP 127.0.0.1 disassociated with Instance 23849038438240934n3294839248")
       @instance.execute_command
     end

--- a/spec/unit/openstack_floating_ip_disassociate_spec.rb
+++ b/spec/unit/openstack_floating_ip_disassociate_spec.rb
@@ -27,8 +27,8 @@ describe Chef::Knife::Cloud::OpenstackFloatingIpDisassociate do
     @instance.name_args = ["127.0.0.1"]
   end
 
-  describe "associate floating ip" do
-    it "calls associate address" do
+  describe "disassociate floating ip" do
+    it "calls disassociate address" do
       @instance.service = Chef::Knife::Cloud::Service.new
       @response = OpenStruct.new(status: 202)
       expect(@instance.service).to receive(:disassociate_address).with("23849038438240934n3294839248", "127.0.0.1").and_return(@response)

--- a/spec/unit/openstack_floating_ip_list_spec.rb
+++ b/spec/unit/openstack_floating_ip_list_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.

--- a/spec/unit/openstack_floating_ip_list_spec.rb
+++ b/spec/unit/openstack_floating_ip_list_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2015 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_floating_ip_release_spec.rb
+++ b/spec/unit/openstack_floating_ip_release_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.

--- a/spec/unit/openstack_floating_ip_release_spec.rb
+++ b/spec/unit/openstack_floating_ip_release_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2015 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_group_list_spec.rb
+++ b/spec/unit/openstack_group_list_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_group_list_spec.rb
+++ b/spec/unit/openstack_group_list_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)

--- a/spec/unit/openstack_image_list_spec.rb
+++ b/spec/unit/openstack_image_list_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_image_list_spec.rb
+++ b/spec/unit/openstack_image_list_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)

--- a/spec/unit/openstack_network_list_spec.rb
+++ b/spec/unit/openstack_network_list_spec.rb
@@ -2,7 +2,7 @@
 #
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright 2014-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_network_list_spec.rb
+++ b/spec/unit/openstack_network_list_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)

--- a/spec/unit/openstack_server_create_spec.rb
+++ b/spec/unit/openstack_server_create_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)

--- a/spec/unit/openstack_server_create_spec.rb
+++ b/spec/unit/openstack_server_create_spec.rb
@@ -4,7 +4,7 @@
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_server_delete_spec.rb
+++ b/spec/unit/openstack_server_delete_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)

--- a/spec/unit/openstack_server_delete_spec.rb
+++ b/spec/unit/openstack_server_delete_spec.rb
@@ -4,7 +4,7 @@
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_server_list_spec.rb
+++ b/spec/unit/openstack_server_list_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_server_list_spec.rb
+++ b/spec/unit/openstack_server_list_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)

--- a/spec/unit/openstack_server_show_spec.rb
+++ b/spec/unit/openstack_server_show_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.

--- a/spec/unit/openstack_server_show_spec.rb
+++ b/spec/unit/openstack_server_show_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_service_spec.rb
+++ b/spec/unit/openstack_service_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_service_spec.rb
+++ b/spec/unit/openstack_service_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)

--- a/spec/unit/openstack_volume_list_spec.rb
+++ b/spec/unit/openstack_volume_list_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/openstack_volume_list_spec.rb
+++ b/spec/unit/openstack_volume_list_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)


### PR DESCRIPTION
Add console/docs gems and rake tasks
Update copyrights / e-mails
Add missing license headers
Remove frozen string literal config from every file
Fix a few bugs in floating IP associate / disassociate. Specs were failing which bubbled up a few places where we improperly accessed the config values and those probably bugs no one ever reported. No idea how these specs passed before.
Add expeditor config
Require at least Chef 13
Adding missing requires for chef/json_compat