### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/chef/knife/openstack_flavor_list.rb
+++ b/lib/chef/knife/openstack_flavor_list.rb
@@ -17,8 +17,8 @@
 #
 
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/openstack_helpers"
-require "chef/knife/cloud/openstack_service_options"
+require_relative "openstack_helpers"
+require_relative "cloud/openstack_service_options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/openstack_floating_ip_allocate.rb
+++ b/lib/chef/knife/openstack_floating_ip_allocate.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require "chef/knife/openstack_helpers"
-require "chef/knife/cloud/openstack_service_options"
+require_relative "openstack_helpers"
+require_relative "cloud/openstack_service_options"
 require "chef/knife/cloud/command"
 
 class Chef

--- a/lib/chef/knife/openstack_floating_ip_associate.rb
+++ b/lib/chef/knife/openstack_floating_ip_associate.rb
@@ -16,9 +16,9 @@
 # limitations under the License.
 #
 
-require "chef/knife/openstack_helpers"
-require "chef/knife/cloud/openstack_service_options"
-require "chef/knife/cloud/openstack_service"
+require_relative "openstack_helpers"
+require_relative "cloud/openstack_service_options"
+require_relative "cloud/openstack_service"
 require "chef/knife/cloud/command"
 
 class Chef

--- a/lib/chef/knife/openstack_floating_ip_disassociate.rb
+++ b/lib/chef/knife/openstack_floating_ip_disassociate.rb
@@ -16,9 +16,9 @@
 # limitations under the License.
 #
 
-require "chef/knife/openstack_helpers"
-require "chef/knife/cloud/openstack_service_options"
-require "chef/knife/cloud/openstack_service"
+require_relative "openstack_helpers"
+require_relative "cloud/openstack_service_options"
+require_relative "cloud/openstack_service"
 require "chef/knife/cloud/command"
 
 class Chef

--- a/lib/chef/knife/openstack_floating_ip_list.rb
+++ b/lib/chef/knife/openstack_floating_ip_list.rb
@@ -17,8 +17,8 @@
 #
 
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/openstack_helpers"
-require "chef/knife/cloud/openstack_service_options"
+require_relative "openstack_helpers"
+require_relative "cloud/openstack_service_options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/openstack_floating_ip_release.rb
+++ b/lib/chef/knife/openstack_floating_ip_release.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require "chef/knife/openstack_helpers"
-require "chef/knife/cloud/openstack_service_options"
+require_relative "openstack_helpers"
+require_relative "cloud/openstack_service_options"
 require "chef/knife/cloud/command"
 
 class Chef

--- a/lib/chef/knife/openstack_group_list.rb
+++ b/lib/chef/knife/openstack_group_list.rb
@@ -16,8 +16,8 @@
 #
 
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/openstack_helpers"
-require "chef/knife/cloud/openstack_service_options"
+require_relative "openstack_helpers"
+require_relative "cloud/openstack_service_options"
 require "chef/json_compat"
 
 class Chef

--- a/lib/chef/knife/openstack_helpers.rb
+++ b/lib/chef/knife/openstack_helpers.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/cloud/openstack_service_options"
+require_relative "cloud/openstack_service_options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/openstack_image_list.rb
+++ b/lib/chef/knife/openstack_image_list.rb
@@ -17,8 +17,8 @@
 #
 
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/openstack_helpers"
-require "chef/knife/cloud/openstack_service_options"
+require_relative "openstack_helpers"
+require_relative "cloud/openstack_service_options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/openstack_network_list.rb
+++ b/lib/chef/knife/openstack_network_list.rb
@@ -17,8 +17,8 @@
 #
 
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/openstack_helpers"
-require "chef/knife/cloud/openstack_service_options"
+require_relative "openstack_helpers"
+require_relative "cloud/openstack_service_options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -19,10 +19,10 @@
 #
 
 require "chef/knife/cloud/server/create_command"
-require "chef/knife/openstack_helpers"
-require "chef/knife/cloud/openstack_server_create_options"
-require "chef/knife/cloud/openstack_service"
-require "chef/knife/cloud/openstack_service_options"
+require_relative "openstack_helpers"
+require_relative "cloud/openstack_server_create_options"
+require_relative "cloud/openstack_service"
+require_relative "cloud/openstack_service_options"
 require "chef/knife/cloud/exceptions"
 
 class Chef

--- a/lib/chef/knife/openstack_server_delete.rb
+++ b/lib/chef/knife/openstack_server_delete.rb
@@ -19,9 +19,9 @@
 
 require "chef/knife/cloud/server/delete_options"
 require "chef/knife/cloud/server/delete_command"
-require "chef/knife/cloud/openstack_service"
-require "chef/knife/cloud/openstack_service_options"
-require "chef/knife/openstack_helpers"
+require_relative "cloud/openstack_service"
+require_relative "cloud/openstack_service_options"
+require_relative "openstack_helpers"
 
 class Chef
   class Knife

--- a/lib/chef/knife/openstack_server_list.rb
+++ b/lib/chef/knife/openstack_server_list.rb
@@ -20,8 +20,8 @@
 #
 
 require "chef/knife/cloud/server/list_command"
-require "chef/knife/openstack_helpers"
-require "chef/knife/cloud/openstack_service_options"
+require_relative "openstack_helpers"
+require_relative "cloud/openstack_service_options"
 require "chef/knife/cloud/server/list_options"
 
 class Chef

--- a/lib/chef/knife/openstack_server_show.rb
+++ b/lib/chef/knife/openstack_server_show.rb
@@ -16,10 +16,10 @@
 #
 
 require "chef/knife/cloud/server/show_command"
-require "chef/knife/openstack_helpers"
+require_relative "openstack_helpers"
 require "chef/knife/cloud/server/show_options"
-require "chef/knife/cloud/openstack_service"
-require "chef/knife/cloud/openstack_service_options"
+require_relative "cloud/openstack_service"
+require_relative "cloud/openstack_service_options"
 require "chef/knife/cloud/exceptions"
 
 class Chef

--- a/lib/chef/knife/openstack_volume_list.rb
+++ b/lib/chef/knife/openstack_volume_list.rb
@@ -19,8 +19,8 @@
 #
 
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/openstack_helpers"
-require "chef/knife/cloud/openstack_service_options"
+require_relative "openstack_helpers"
+require_relative "cloud/openstack_service_options"
 require "chef/json_compat"
 
 class Chef


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>