### PR TITLE
Start the move to Fog 2.x

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -22,7 +22,7 @@ fi
 bundle config --local path vendor/bundle
 
 bundle install --jobs=7 --retry=3
-bundle exec $1
+bundle exec $@
 
 if [[ -f bundle.tar.gz && -f bundle.sha256  ]]; then # dont' check the sha if we're missing either file
   if shasum --check bundle.sha256 --status; then # if the the sha matches we're done

--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -2,43 +2,15 @@
 #
 # This script runs a passed in command, but first setups up the bundler caching on the repo
 
-set -e
+set -ue
 
 export USER="root"
+export LANG=C.UTF-8 LANGUAGE=C.UTF-8
 
-# make sure we have the aws cli
-apt-get update -y
-apt-get install awscli -y
+echo "--- bundle install"
 
-# grab the s3 bundler if it's there and use it for all operations in bundler
-echo "Fetching bundle cache archive from s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz"
-aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz" bundle.tar.gz || echo 'Could not pull the bundler archive from s3 for caching. Builds may be slower than usual as all gems will have to install.'
-aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.sha256" bundle.sha256 || echo "Could not pull the sha256 hash of the vendor/bundle directory from s3. Without this we will compress and upload the bundler archive to S3 even if it hasn't changed"
-
-echo "Restoring the bundle cache archive to vendor/bundle"
-if [ -f bundle.tar.gz ]; then
-  tar -xzf bundle.tar.gz
-fi
 bundle config --local path vendor/bundle
-
 bundle install --jobs=7 --retry=3
+
+echo "+++ bundle exec task"
 bundle exec $@
-
-if [[ -f bundle.tar.gz && -f bundle.sha256  ]]; then # dont' check the sha if we're missing either file
-  if shasum --check bundle.sha256 --status; then # if the the sha matches we're done
-    echo "Bundled gems have not changed. Skipping upload to s3"
-    exit
-  fi
-fi
-
-echo "Generating sha256 hash file of the vendor/bundle directory to ship to s3"
-shasum -a 256 vendor/bundle > bundle.sha256
-
-echo "Creating the tar.gz to of the vendor/bundle directory to ship to s3"
-tar -czf bundle.tar.gz vendor/
-
-echo "Uploading the tar.gz of the vendor/bundle directory to s3"
-aws s3 cp bundle.tar.gz "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz" || echo 'Could not push the bundler directory to s3 for caching. Future builds may be slower if this continues.'
-
-echo "Uploading the sha256 hash of the vendor/bundle directory to s3"
-aws s3 cp bundle.sha256 "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.sha256" || echo 'Could not push the bundler directory to s3 for caching. Future builds may be slower if this continues.'

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,3 +1,14 @@
+---
+expeditor:
+  cached_folders:
+    - vendor
+  defaults:
+    buildkite:
+      retry:
+        automatic:
+          limit: 1
+      timeout_in_minutes: 30
+
 steps:
 
 - label: lint-chefstyle

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -16,3 +16,11 @@ steps:
       docker:
         image: ruby:2.6-buster
 
+- label: run-specs-ruby-2.7
+  command:
+    - .expeditor/run_linux_tests.sh "rake spec"
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.7-buster
+

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -8,15 +8,6 @@ steps:
       docker:
         image: ruby:2.6-buster
 
-
-- label: run-specs-ruby-2.5
-  command:
-    - .expeditor/run_linux_tests.sh "rake spec"
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-buster
-
 - label: run-specs-ruby-2.6
   command:
     - .expeditor/run_linux_tests.sh "rake spec"

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ binstubs/
 .direnv/
 .envrc
 .ruby-version
+.ruby-gemset
 
 # Documentation
 _site/*

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :docs do
 end
 
 group :test do
-  gem "chefstyle", "0.14.1"
+  gem "chefstyle", "0.15.1"
   gem "guard-rspec"
   gem "mixlib-shellout"
   gem "rake"

--- a/README.md
+++ b/README.md
@@ -37,21 +37,10 @@ chef gem install knife-openstack
 
 ## Configuration
 
-In order to communicate with an OpenStack API you will need to tell Knife your OpenStack Auth API endpoint, your Dashboard username and password (tenant is optional). The easiest way to accomplish this is to create these entries in your `knife.rb` file:
+In order to communicate with an OpenStack API you will need to tell Knife your OpenStack Auth API endpoint, your Dashboard username and password. The easiest way to accomplish this is to create these entries in your `knife.rb` file:
 
 ```ruby
-### Note: If you are not proxying HTTPS to the OpenStack auth port, the scheme should be HTTP
-knife[:openstack_auth_url] = "http://cloud.mycompany.com:5000/v2.0/tokens"
-knife[:openstack_username] = "Your OpenStack Dashboard username"
-knife[:openstack_password] = "Your OpenStack Dashboard password"
-knife[:openstack_tenant] = "Your OpenStack tenant name"
-knife[:openstack_region] = "Your OpenStack Region"
-```
-
-All of Fog's `openstack` options (`openstack_domain_name`, `openstack_project_name`, ...) are supported. This includes support for the OpenStack Identity v3
-
-```ruby
-knife[:openstack_auth_url] = "http://cloud.mycompany.com:5000/v3/auth/tokens"
+knife[:openstack_auth_url] = "https://cloud.mycompany.com:5000/v3/"
 knife[:openstack_username] = "Your OpenStack Dashboard username"
 knife[:openstack_password] = "Your OpenStack Dashboard password"
 knife[:openstack_project_name] = "Your OpenStack project"
@@ -61,11 +50,11 @@ knife[:openstack_domain_name] = "Your OpenStack domain"
 If your knife.rb file will be checked into a SCM system (ie readable by others) you may want to read the values from environment variables. For example, using the conventions of [OpenStack's RC file](http://docs.openstack.org/user-guide/content/cli_openrc.html) (note the `openstack_auth_url`):
 
 ```ruby
-knife[:openstack_auth_url] = "#{ENV['OS_AUTH_URL']}/tokens"
-knife[:openstack_username] = "#{ENV['OS_USERNAME']}"
-knife[:openstack_password] = "#{ENV['OS_PASSWORD']}"
-knife[:openstack_tenant] = "#{ENV['OS_TENANT_NAME']}"
-knife[:openstack_region] = "#{ENV['OS_REGION_NAME']}"
+knife[:openstack_auth_url] = ENV['OS_AUTH_URL']
+knife[:openstack_username] = ENV['OS_USERNAME']
+knife[:openstack_password] = ENV['OS_PASSWORD']
+knife[:openstack_project_name] = ENV['OS_PROJECT_NAME']
+knife[:openstack_domain_name] = ENV['OS_USER_DOMAIN_NAME']
 ```
 
 If your OpenStack deployment is over SSL, but does not have a valid certificate, you can add the following option to bypass SSL check:
@@ -168,6 +157,8 @@ Author:: Matt Ray ([matt@chef.io](mailto:matt@chef.io))
 Author:: Chirag Jog ([chirag@clogeny.com](mailto:chirag@clogeny.com))
 
 Author:: JJ Asghar ([jj@chef.io](mailto:jj@chef.io))
+
+Author:: Lance Albertson ([lance@osuosl.org](mailto:lance@osuosl.org))
 
 Copyright:: Copyright 2011-2018 Chef Software, Inc.
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Note: Documentation needs to be updated in chef docs
 
 ## Requirements
 
-- Chef 12.0 higher
-- Ruby 2.2.2 or higher
+- Chef 15.0 higher
+- Ruby 2.6 or higher
 
 ## Installation
 

--- a/knife-openstack.gemspec
+++ b/knife-openstack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3"
 
   s.add_dependency "fog-openstack", "~> 1.0"
-  s.add_dependency "chef", ">= 13"
+  s.add_dependency "chef", ">= 15"
   s.add_dependency "knife-cloud", ">= 3.0", "< 4.0"
 
 end

--- a/knife-openstack.gemspec
+++ b/knife-openstack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.3"
 
-  s.add_dependency "fog", "~> 1.23"
+  s.add_dependency "fog", "~> 2.0"
   s.add_dependency "chef", ">= 13"
   s.add_dependency "knife-cloud", ">= 1.2.0", "< 3.0"
 

--- a/knife-openstack.gemspec
+++ b/knife-openstack.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.3"
 
-  s.add_dependency "fog", "~> 2.0"
+  s.add_dependency "fog-openstack", "~> 1.0"
   s.add_dependency "chef", ">= 13"
-  s.add_dependency "knife-cloud", ">= 1.2.0", "< 3.0"
+  s.add_dependency "knife-cloud", ">= 3.0", "< 4.0"
 
 end

--- a/lib/chef/knife/cloud/openstack_service.rb
+++ b/lib/chef/knife/cloud/openstack_service.rb
@@ -67,8 +67,8 @@ class Chef
           }
 
           (
-            Fog::Compute::OpenStack.requirements +
-            Fog::Compute::OpenStack.recognized -
+            Fog::OpenStack::Compute.requirements +
+            Fog::OpenStack::Compute.recognized -
             [:openstack_api_key]
           ).each do |k|
             next unless k.to_s.start_with?("openstack")

--- a/lib/chef/knife/cloud/openstack_service.rb
+++ b/lib/chef/knife/cloud/openstack_service.rb
@@ -18,6 +18,7 @@
 #
 
 require "chef/knife/cloud/fog/service"
+require "fog/openstack"
 
 class Chef
   class Knife

--- a/lib/chef/knife/cloud/openstack_service.rb
+++ b/lib/chef/knife/cloud/openstack_service.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Kaustubh Deorukhkar (<kaustubh@clogeny.com>)
+# Author:: Lance Albertson(<lance@osuosl.org>)
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #

--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -175,11 +175,11 @@ class Chef
 
           errors = []
 
-          if locate_config_value(:bootstrap_protocol) == "winrm"
-            if locate_config_value(:winrm_password).nil?
-              errors << "You must provide Winrm Password."
+          if locate_config_value(:connection_protocol) == "winrm"
+            if locate_config_value(:connection_password).nil?
+              errors << "You must provide Connection Password."
             end
-          elsif locate_config_value(:bootstrap_protocol) != "ssh"
+          elsif locate_config_value(:connection_protocol) != "ssh"
             errors << "You must provide a valid bootstrap protocol. options [ssh/winrm]. For linux type images, options [ssh]"
           end
 

--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -208,16 +208,16 @@ class Chef
           # floating requested without value
           if address.nil?
             if addresses.find_index { |a| a.fixed_ip.nil? }
-              return true
+              true
             else
-              return false # no floating IPs available
+              false # no floating IPs available
             end
           else
             # floating requested with value
             if addresses.find_index { |a| a.ip == address }
-              return true
+              true
             else
-              return false # requested floating IP does not exist
+              false # requested floating IP does not exist
             end
           end
         end

--- a/lib/chef/knife/openstack_server_create.rb
+++ b/lib/chef/knife/openstack_server_create.rb
@@ -2,6 +2,7 @@
 # Author:: Seth Chisamore (<schisamo@chef.io>)
 # Author:: Matt Ray (<matt@chef.io>)
 # Author:: Chirag Jog (<chirag@clogeny.com>)
+# Author:: Lance Albertson (<lance@osuosl.org>)
 # Copyright:: Copyright 2011-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #

--- a/lib/chef/knife/openstack_volume_list.rb
+++ b/lib/chef/knife/openstack_volume_list.rb
@@ -33,7 +33,7 @@ class Chef
         banner "knife openstack volume list (options)"
 
         def query_resource
-          @service.connection.volumes
+          @service.connection.volumes.all({})
         rescue Excon::Errors::BadRequest => e
           response = Chef::JSONCompat.from_json(e.response.body)
           ui.fatal("Unknown server error (#{response["badRequest"]["code"]}): #{response["badRequest"]["message"]}")

--- a/lib/chef/knife/openstack_volume_list.rb
+++ b/lib/chef/knife/openstack_volume_list.rb
@@ -2,6 +2,7 @@
 # Author:: Seth Chisamore (<schisamo@chef.io>)
 # Author:: Matt Ray (<matt@chef.io>)
 # Author:: Evan Felix (<karcaw@gmail.com>)
+# Author:: Lance Albertson (<lance@osuosl.org>)
 # Copyright:: Copyright 2011-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #

--- a/spec/functional/server_create_func_spec.rb
+++ b/spec/functional/server_create_func_spec.rb
@@ -69,7 +69,7 @@ describe Chef::Knife::Cloud::OpenstackServerCreate do
   describe "run" do
     before(:each) do
       allow(@knife_openstack_create).to receive(:validate_params!)
-      allow(Fog::Compute::OpenStack).to receive_message_chain(:new, :servers, :create).and_return(@new_openstack_server)
+      allow(Fog::OpenStack::Compute).to receive_message_chain(:new, :servers, :create).and_return(@new_openstack_server)
       @knife_openstack_create.config[:openstack_floating_ip] = "-1"
       allow(@new_openstack_server).to receive(:wait_for)
     end

--- a/spec/functional/server_create_func_spec.rb
+++ b/spec/functional/server_create_func_spec.rb
@@ -5,6 +5,7 @@
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
+# Author:: Lance Albertson (<lance@osuosl.org>)
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #

--- a/spec/functional/server_create_func_spec.rb
+++ b/spec/functional/server_create_func_spec.rb
@@ -76,11 +76,11 @@ describe Chef::Knife::Cloud::OpenstackServerCreate do
 
     context "for Linux" do
       before do
-        @config = { openstack_floating_ip: "-1", bootstrap_ip_address: "75.101.253.10", ssh_password: "password", hints: { "openstack" => {} } }
+        @config = { openstack_floating_ip: "-1", bootstrap_ip_address: "75.101.253.10", ssh_password: "password", hints: { "openstack" => {} }, distro: "chef-full" }
         @knife_openstack_create.config[:distro] = "chef-full"
         @bootstrapper = Chef::Knife::Cloud::Bootstrapper.new(@config)
         @ssh_bootstrap_protocol = Chef::Knife::Cloud::SshBootstrapProtocol.new(@config)
-        @unix_distribution = Chef::Knife::Cloud::UnixDistribution.new(@config)
+        @bootstrapdistribution = Chef::Knife::Cloud::BootstrapDistribution.new(@config)
         allow(@ssh_bootstrap_protocol).to receive(:send_bootstrap_command)
       end
 
@@ -88,7 +88,7 @@ describe Chef::Knife::Cloud::OpenstackServerCreate do
         expect(Chef::Knife::Cloud::Bootstrapper).to receive(:new).with(@config).and_return(@bootstrapper)
         allow(@bootstrapper).to receive(:bootstrap).and_call_original
         expect(@bootstrapper).to receive(:create_bootstrap_protocol).and_return(@ssh_bootstrap_protocol)
-        expect(@bootstrapper).to receive(:create_bootstrap_distribution).and_return(@unix_distribution)
+        expect(@bootstrapper).to receive(:create_bootstrap_distribution).and_return(@bootstrapdistribution)
         expect(@openstack_service).to receive(:server_summary).exactly(2).times
         @knife_openstack_create.run
       end
@@ -96,19 +96,19 @@ describe Chef::Knife::Cloud::OpenstackServerCreate do
 
     context "for Windows" do
       before do
-        @config = { openstack_floating_ip: "-1", image_os_type: "windows", bootstrap_ip_address: "75.101.253.10", bootstrap_protocol: "winrm", ssh_password: "password", hints: { "openstack" => {} } }
+        @config = { openstack_floating_ip: "-1", image_os_type: "windows", bootstrap_ip_address: "75.101.253.10", bootstrap_protocol: "winrm", ssh_password: "password", hints: { "openstack" => {} }, distro: "windows-chef-client-msi" }
         @knife_openstack_create.config[:image_os_type] = "windows"
         @knife_openstack_create.config[:bootstrap_protocol] = "winrm"
         @knife_openstack_create.config[:distro] = "windows-chef-client-msi"
         @bootstrapper = Chef::Knife::Cloud::Bootstrapper.new(@config)
         @winrm_bootstrap_protocol = Chef::Knife::Cloud::WinrmBootstrapProtocol.new(@config)
-        @windows_distribution = Chef::Knife::Cloud::WindowsDistribution.new(@config)
+        @bootstrapdistribution = Chef::Knife::Cloud::BootstrapDistribution.new(@config)
       end
       it "Creates an OpenStack instance for Windows and bootstraps it" do
         expect(Chef::Knife::Cloud::Bootstrapper).to receive(:new).with(@config).and_return(@bootstrapper)
         allow(@bootstrapper).to receive(:bootstrap).and_call_original
         expect(@bootstrapper).to receive(:create_bootstrap_protocol).and_return(@winrm_bootstrap_protocol)
-        expect(@bootstrapper).to receive(:create_bootstrap_distribution).and_return(@windows_distribution)
+        expect(@bootstrapper).to receive(:create_bootstrap_distribution).and_return(@bootstrapdistribution)
         allow(@winrm_bootstrap_protocol).to receive(:send_bootstrap_command)
         expect(@openstack_service).to receive(:server_summary).exactly(2).times
         @knife_openstack_create.run

--- a/spec/functional/server_delete_func_spec.rb
+++ b/spec/functional/server_delete_func_spec.rb
@@ -24,7 +24,7 @@ require "chef/knife/cloud/openstack_service"
 
 describe Chef::Knife::Cloud::OpenstackServerDelete do
   before do
-    @openstack_connection = double(Fog::Compute::OpenStack)
+    @openstack_connection = double(Fog::OpenStack::Compute)
     @chef_node = double(Chef::Node)
     @chef_client = double(Chef::ApiClient)
     @knife_openstack_delete = Chef::Knife::Cloud::OpenstackServerDelete.new
@@ -63,7 +63,7 @@ describe Chef::Knife::Cloud::OpenstackServerDelete do
     it "deletes an OpenStack instance." do
       expect(@openstack_servers).to receive(:get).and_return(@running_openstack_server)
       expect(@openstack_connection).to receive(:servers).and_return(@openstack_servers)
-      expect(Fog::Compute::OpenStack).to receive(:new).and_return(@openstack_connection)
+      expect(Fog::OpenStack::Compute).to receive(:new).and_return(@openstack_connection)
       expect(@running_openstack_server).to receive(:destroy)
       @knife_openstack_delete.run
     end
@@ -76,7 +76,7 @@ describe Chef::Knife::Cloud::OpenstackServerDelete do
       expect(@chef_client).to receive(:destroy)
       expect(@openstack_servers).to receive(:get).and_return(@running_openstack_server)
       expect(@openstack_connection).to receive(:servers).and_return(@openstack_servers)
-      expect(Fog::Compute::OpenStack).to receive(:new).and_return(@openstack_connection)
+      expect(Fog::OpenStack::Compute).to receive(:new).and_return(@openstack_connection)
       expect(@running_openstack_server).to receive(:destroy)
       @knife_openstack_delete.run
     end

--- a/spec/resource_spec_helper.rb
+++ b/spec/resource_spec_helper.rb
@@ -1,0 +1,50 @@
+#
+# Author:: Prabhu Das (<prabhu.das@clogeny.com>)
+# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+$:.unshift File.expand_path("../../lib", __FILE__)
+require "json"
+
+# Creates a resource class that can dynamically add attributes to
+# instances and set the values
+module JSONModule
+  def to_json
+    hash = {}
+    instance_variables.each do |var|
+      hash[var] = instance_variable_get var
+    end
+    hash.to_json
+  end
+
+  def from_json!(string)
+    JSON.load(string).each do |var, val|
+      instance_variable_set var, val
+    end
+  end
+end
+
+class TestResource
+  include JSONModule
+  def initialize(*args)
+    args.each do |arg|
+      arg.each do |key, value|
+        add_attribute = "class << self; attr_accessor :#{key}; end"
+        eval(add_attribute) # rubocop:disable Security/Eval
+        eval("@#{key} = value") # rubocop:disable Security/Eval
+      end
+    end
+  end
+end

--- a/spec/server_command_common_spec_helper.rb
+++ b/spec/server_command_common_spec_helper.rb
@@ -1,0 +1,48 @@
+#
+# Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
+# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+$:.unshift File.expand_path("../../lib", __FILE__)
+
+# Common helper methods used accrossed knife plugin during Integration testing.
+#
+# run_cmd_check_status_and_output: It checks knife plugin command exitstatus(i.e '0' = succeed and '1' = fails)
+# and also checks command output(i.e stdout or stderr)
+#
+# run_cmd_check_stdout: It checks commands stdout.
+#
+# server_create_common_bfr_aftr: Its contains common before and after blocks used for server create
+
+def run_cmd_check_status_and_output(expected_status = "succeed", expected_result = nil)
+  it do
+    match_status("should #{expected_status}")
+    expect(cmd_output).to include(expected_result) if expected_result
+  end
+end
+
+def run_cmd_check_stdout(expected_result)
+  it { match_stdout(/#{expected_result}/) }
+end
+
+def server_create_common_bfr_aftr(platform = "linux")
+  before { create_node_name(platform) }
+  after { run(delete_instance_cmd("#{cmd_output}")) }
+end
+
+def rm_known_host
+  known_hosts = File.expand_path("~") + "/.ssh/known_hosts"
+  FileUtils.rm_rf(known_hosts)
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,12 +19,9 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "chef/knife/bootstrap"
 require "chef/knife/openstack_helpers"
-require "fog"
-require "chef/knife/winrm_base"
-require "chef/knife/bootstrap_windows_winrm"
+require "fog/openstack"
 require "chef/knife/openstack_server_create"
 require "chef/knife/openstack_server_delete"
-require "chef/knife/bootstrap_windows_ssh"
 require "securerandom"
 require "knife-openstack/version"
 require "test/knife-utils/test_bed"

--- a/spec/support/shared_examples_for_command.rb
+++ b/spec/support/shared_examples_for_command.rb
@@ -1,0 +1,35 @@
+#
+# Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
+# Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "chef/knife/cloud/command"
+require "chef/knife/cloud/service"
+
+shared_examples_for Chef::Knife::Cloud::Command do |instance|
+  it "runs with correct method calls" do
+    allow(instance).to receive(:execute_command)
+    allow(instance).to receive(:create_service_instance).and_return(Chef::Knife::Cloud::Service.new)
+    expect(instance).to receive(:set_default_config).ordered
+    expect(instance).to receive(:validate!).ordered
+    expect(instance).to receive(:validate_params!).ordered
+    expect(instance).to receive(:create_service_instance).ordered
+    expect(instance).to receive(:before_exec_command).ordered
+    expect(instance).to receive(:execute_command).ordered
+    expect(instance).to receive(:after_exec_command).ordered
+    instance.run
+  end
+end

--- a/spec/support/shared_examples_for_command_bootstrap.rb
+++ b/spec/support/shared_examples_for_command_bootstrap.rb
@@ -1,0 +1,35 @@
+#
+# Author:: Ashwini Nehate(<ashwini.nehate@msystechnologies.com>)
+# Author:: Kapil Chouhan (<kapil.chouhan@msystechnologies.com>)
+# Copyright:: Copyright (c) 2008-2019 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "chef/knife/cloud/command_bootstrap"
+require "chef/knife/cloud/service"
+
+shared_examples_for Chef::Knife::Cloud::BootstrapCommand do |instance|
+  it "runs with correct method calls" do
+    allow(instance).to receive(:execute_command)
+    allow(instance).to receive(:create_service_instance).and_return(Chef::Knife::Cloud::Service.new)
+    expect(instance).to receive(:set_default_config).ordered
+    expect(instance).to receive(:validate!).ordered
+    expect(instance).to receive(:validate_params!).ordered
+    expect(instance).to receive(:create_service_instance).ordered
+    expect(instance).to receive(:before_exec_command).ordered
+    expect(instance).to receive(:execute_command).ordered
+    expect(instance).to receive(:after_exec_command).ordered
+    instance.run
+  end
+end

--- a/spec/support/shared_examples_for_servercreatecommand.rb
+++ b/spec/support/shared_examples_for_servercreatecommand.rb
@@ -1,0 +1,144 @@
+#
+# Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
+# Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "spec_helper"
+require "chef/knife/cloud/server/create_command"
+
+def get_mock_resource(id)
+  obj = Object.new
+  allow(obj).to receive(:id).and_return(id)
+  obj
+end
+
+shared_examples_for Chef::Knife::Cloud::ServerCreateCommand do |instance|
+  before do
+    instance.service = double
+    allow(instance.ui).to receive(:fatal)
+
+    allow(instance.service).to receive(:get_image).and_return(get_mock_resource("image_id"))
+
+    allow(instance.service).to receive(:get_flavor).and_return(get_mock_resource("flavor_id"))
+  end
+
+  describe "#before_exec_command" do
+    it "calls create_server_dependencies" do
+      expect(instance.service).to receive(:create_server_dependencies)
+      instance.before_exec_command
+    end
+    it "delete_server_dependencies on any error" do
+      allow(instance).to receive(:execute_command)
+      allow(instance).to receive(:after_exec_command)
+      allow(instance).to receive(:validate!)
+      allow(instance).to receive(:validate_params!)
+      instance.service = Chef::Knife::Cloud::Service.new
+      allow(instance).to receive(:create_service_instance).and_return(instance.service)
+      allow(instance.service).to receive(:get_image).and_return(get_mock_resource("image_id"))
+      allow(instance.service).to receive(:get_flavor).and_return(get_mock_resource("flavor_id"))
+      allow(instance.service).to receive(:create_server_dependencies).and_raise(Chef::Knife::Cloud::CloudExceptions::ServerCreateDependenciesError)
+      expect(instance.service).to receive(:delete_server_dependencies)
+      expect(instance.service).to_not receive(:delete_server_on_failure)
+      expect(instance).to receive(:exit)
+      instance.run
+    end
+  end
+
+  describe "#execute_command" do
+    it "calls create_server" do
+      expect(instance.service).to receive(:create_server).and_return(true)
+      expect(instance.service).to receive(:server_summary)
+      instance.execute_command
+    end
+
+    it "delete_server_dependencies on any error" do
+      allow(instance).to receive(:before_exec_command)
+      allow(instance).to receive(:after_exec_command)
+      allow(instance).to receive(:validate!)
+      allow(instance).to receive(:validate_params!)
+      instance.service = Chef::Knife::Cloud::Service.new
+      allow(instance).to receive(:create_service_instance).and_return(instance.service)
+      allow(instance.service).to receive(:create_server).and_raise(Chef::Knife::Cloud::CloudExceptions::ServerCreateError)
+      expect(instance.service).to receive(:delete_server_dependencies)
+      expect(instance.service).to_not receive(:delete_server_on_failure)
+      expect(instance).to receive(:exit)
+      instance.run
+    end
+  end
+
+  describe "#bootstrap" do
+    it "execute with correct method calls" do
+      @bootstrap = Object.new
+      allow(@bootstrap).to receive(:bootstrap)
+      allow(instance.ui).to receive(:info)
+      allow(Chef::Knife::Cloud::Bootstrapper).to receive(:new).and_return(@bootstrap)
+      expect(instance).to receive(:before_bootstrap).ordered
+      expect(instance).to receive(:after_bootstrap).ordered
+      instance.bootstrap
+    end
+  end
+
+  describe "#after_bootstrap" do
+    it "display server summary" do
+      expect(instance.service).to receive(:server_summary)
+      instance.after_bootstrap
+    end
+  end
+
+  describe "#get_node_name" do
+    it "auto generates chef_node_name" do
+      instance.config[:connection_protocol] = "ssh"
+      instance.config[:connection_password] = "password"
+      instance.config[:image_os_type] = "linux"
+      instance.config[:chef_node_name_prefix] = "os"
+      expect(instance).to receive(:get_node_name).and_call_original
+      instance.validate_params!
+      expect(instance.config[:chef_node_name]).to be =~ /os-*/
+    end
+
+    it "auto generates unique chef_node_name" do
+      node_names = []
+      instance.config[:connection_protocol] = "ssh"
+      instance.config[:connection_password] = "password"
+      instance.config[:image_os_type] = "linux"
+      instance.config[:chef_node_name_prefix] = "os"
+      5.times do
+        instance.config[:chef_node_name] = nil
+        instance.validate_params!
+        expect(node_names).to_not include(instance.config[:chef_node_name])
+        node_names.push(instance.config[:chef_node_name])
+      end
+    end
+  end
+
+  describe "#cleanup_on_failure" do
+    it "delete server dependencies on delete_server_on_failure set" do
+      instance.config[:delete_server_on_failure] = true
+      instance.service = Chef::Knife::Cloud::Service.new
+      expect(instance.service).to receive(:delete_server_dependencies)
+      expect(instance.service).to receive(:delete_server_on_failure)
+      instance.cleanup_on_failure
+    end
+
+    it "don't delete server dependencies on delete_server_on_failure option is missing" do
+      instance.config[:delete_server_on_failure] = false
+      Chef::Config[:knife].delete(:delete_server_on_failure)
+      expect(instance.service).to_not receive(:delete_server_dependencies)
+      expect(instance.service).to_not receive(:delete_server_on_failure)
+      instance.cleanup_on_failure
+    end
+  end
+end

--- a/spec/support/shared_examples_for_serverdeletecommand.rb
+++ b/spec/support/shared_examples_for_serverdeletecommand.rb
@@ -1,0 +1,76 @@
+#
+# Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
+# Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "chef/knife/cloud/server/delete_command"
+
+shared_examples_for Chef::Knife::Cloud::ServerDeleteCommand do |instance|
+  describe "#delete_from_chef" do
+    it "expects chef warning message when purge option is disabled" do
+      server_name = "testserver"
+      expect(instance.ui).to receive(:warn).with("Corresponding node and client for the #{server_name} server were not deleted and remain registered with the Chef Server")
+      instance.delete_from_chef(server_name)
+    end
+
+    it "deletes chef node and client when purge option is enabled" do
+      instance.config[:purge] = true
+      server_name = "testserver"
+      expect(instance).to receive(:destroy_item).with(Chef::Node, server_name, "node").ordered
+      expect(instance).to receive(:destroy_item).with(Chef::ApiClient, server_name, "client").ordered
+      instance.delete_from_chef(server_name)
+    end
+
+    it "deletes chef node specified with node-name option overriding the instance server_name" do
+      instance.config[:purge] = true
+      chef_node_name = "testnode"
+      instance.config[:chef_node_name] = chef_node_name
+      expect(instance).to receive(:destroy_item).with(Chef::Node, chef_node_name, "node").ordered
+      expect(instance).to receive(:destroy_item).with(Chef::ApiClient, chef_node_name, "client").ordered
+      instance.delete_from_chef(chef_node_name)
+    end
+  end
+
+  describe "#execute_command" do
+    it "execute with correct method calls" do
+      instance.name_args = ["testserver"]
+      instance.service = double
+      expect(instance.service).to receive(:delete_server).ordered
+      expect(instance).to receive(:delete_from_chef).ordered
+      instance.execute_command
+    end
+  end
+
+  describe "#destroy_item" do
+    it "destroy chef node" do
+      node_name = "testnode"
+      test_obj = Object.new
+      allow(Chef::Node).to receive(:load).and_return(test_obj)
+      allow(test_obj).to receive(:destroy)
+      expect(instance.ui).to receive(:warn).with("Deleted node #{node_name}")
+      instance.destroy_item(Chef::Node, node_name, "node")
+    end
+
+    it "destroy chef client" do
+      client_name = "testclient"
+      test_obj = Object.new
+      allow(Chef::ApiClient).to receive(:load).and_return(test_obj)
+      allow(test_obj).to receive(:destroy)
+      expect(instance.ui).to receive(:warn).with("Deleted client #{client_name}")
+      instance.destroy_item(Chef::ApiClient, client_name, "client")
+    end
+  end
+end

--- a/spec/support/shared_examples_for_service.rb
+++ b/spec/support/shared_examples_for_service.rb
@@ -1,0 +1,85 @@
+#
+# Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
+# Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "chef/knife/cloud/service"
+
+shared_examples_for Chef::Knife::Cloud::Service do |instance|
+
+  describe "#connection" do
+    it "creates a connection to fog service." do
+      expect(instance).to receive(:add_api_endpoint)
+      expect(Fog::Compute).to receive(:new)
+      instance.connection
+    end
+  end
+
+  describe "#delete_server" do
+    it "deletes the server." do
+      server = double
+      allow(instance).to receive(:puts)
+      allow(instance).to receive_message_chain(:connection, :servers, :get).and_return(server)
+      expect(server).to receive(:name).ordered
+      expect(server).to receive(:id).ordered
+      allow(instance).to receive_message_chain(:ui, :confirm)
+      expect(server).to receive(:destroy).ordered
+      instance.delete_server(:server_name)
+    end
+
+    it "throws error message when the server cannot be located." do
+      server_name = "invalid_server_name"
+      error_message = "Could not locate server '#{server_name}'."
+      allow(instance).to receive_message_chain(:connection, :servers, :get).and_return(nil)
+      allow(instance).to receive_message_chain(:ui, :error).with(error_message)
+      expect { instance.delete_server(server_name) }.to raise_error(Chef::Knife::Cloud::CloudExceptions::ServerDeleteError)
+    end
+  end
+
+  describe "#create_server" do
+    before do
+      allow(instance).to receive(:puts)
+      allow(instance).to receive(:print)
+    end
+
+    it "creates the server." do
+      server = double
+      allow(instance).to receive_message_chain(:connection, :servers, :create).and_return(server)
+      allow(instance).to receive_message_chain(:ui, :color)
+      expect(server).to receive(:wait_for)
+      instance.create_server({ server_create_timeout: 600 })
+    end
+  end
+
+  describe "#get_server" do
+    it "return server." do
+      server = double
+      allow(instance).to receive_message_chain(:connection, :servers, :create).and_return(server)
+      expect(instance.connection.servers).to receive(:get)
+      instance.get_server("instance_id")
+    end
+  end
+
+  describe "#server_summary" do
+    it "show server details." do
+      server = double
+      instance.ui = double
+      expect(instance.ui).to receive(:list)
+      expect(server).to receive(:id)
+      instance.server_summary(server, [{ label: "Instance ID", key: "id" }])
+    end
+  end
+end

--- a/spec/unit/openstack_server_create_spec.rb
+++ b/spec/unit/openstack_server_create_spec.rb
@@ -4,6 +4,7 @@
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
+# Author:: Lance Albertson (<lance@osuosl.org>)
 # Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #

--- a/spec/unit/openstack_server_create_spec.rb
+++ b/spec/unit/openstack_server_create_spec.rb
@@ -49,7 +49,7 @@ describe Chef::Knife::Cloud::OpenstackServerCreate do
     before(:each) do
       @instance = Chef::Knife::Cloud::OpenstackServerCreate.new
       allow(@instance.ui).to receive(:error)
-      Chef::Config[:knife][:bootstrap_protocol] = "ssh"
+      Chef::Config[:knife][:connection_protocol] = "ssh"
       Chef::Config[:knife][:identity_file] = "identity_file"
       Chef::Config[:knife][:image_os_type] = "linux"
       Chef::Config[:knife][:openstack_ssh_key_id] = "openstack_ssh_key"
@@ -57,7 +57,7 @@ describe Chef::Knife::Cloud::OpenstackServerCreate do
     end
 
     after(:all) do
-      Chef::Config[:knife].delete(:bootstrap_protocol)
+      Chef::Config[:knife].delete(:connection_protocol)
       Chef::Config[:knife].delete(:identity_file)
       Chef::Config[:knife].delete(:image_os_type)
       Chef::Config[:knife].delete(:openstack_ssh_key_id)


### PR DESCRIPTION
kitchen-openstack requires fog 2.x so we should also require fog 2.x here.

Signed-off-by: Tim Smith <tsmith@chef.io>